### PR TITLE
fix(pricing): add temporary alias for gpt-5.3-codex to fallback on gpt-5.2-codex pricing

### DIFF
--- a/docs/pricing-and-costs.md
+++ b/docs/pricing-and-costs.md
@@ -63,6 +63,10 @@ LiteLLM model lookup tries, in order:
 
 Resolved aliases are cached in memory per process run.
 
+Temporary compatibility alias currently configured:
+
+- `gpt-5.3-codex` -> `gpt-5.2-codex` (used only while upstream direct `gpt-5.3-codex` token pricing is unavailable)
+
 ## Cost engine
 
 Source file: `src/pricing/cost-engine.ts`

--- a/src/pricing/litellm-model-map.json
+++ b/src/pricing/litellm-model-map.json
@@ -10,7 +10,12 @@
     "claude-sonnet-4.6": "claude-sonnet-4.6",
     "claude-sonnet-4-6": "claude-sonnet-4.6",
     "anthropic/claude-sonnet-4.6": "claude-sonnet-4.6",
-    "anthropic.claude-sonnet-4-6": "claude-sonnet-4.6"
+    "anthropic.claude-sonnet-4-6": "claude-sonnet-4.6",
+
+    "gpt-5.3-codex": "gpt-5.2-codex"
+  },
+  "notes": {
+    "gpt-5.3-codex": "Temporary fallback to gpt-5.2-codex until upstream publishes direct gpt-5.3-codex token pricing"
   },
   "preferredPricingKeyByCanonicalModel": {
     "kimi-k2.5": "moonshot/kimi-k2.5",

--- a/tests/pricing/litellm-pricing-fetcher.test.ts
+++ b/tests/pricing/litellm-pricing-fetcher.test.ts
@@ -294,8 +294,8 @@ describe('LiteLLMPricingFetcher', () => {
     expect(fetcher.getPricing('claude sonnet 4.6')?.outputPer1MUsd).toBeCloseTo(15, 10);
   });
 
-  it('does not incorrectly map gpt-5.3-codex to gpt-5.2-codex pricing', async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), 'litellm-pricing-no-cross-version-'));
+  it('maps gpt-5.3-codex through a temporary gpt-5.2-codex fallback alias until upstream direct pricing exists', async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), 'litellm-pricing-codex-fallback-'));
     tempDirs.push(rootDir);
 
     const fetcher = createFetcher({
@@ -319,7 +319,8 @@ describe('LiteLLMPricingFetcher', () => {
 
     await fetcher.load();
 
-    expect(fetcher.getPricing('gpt-5.3-codex')).toBeUndefined();
+    expect(fetcher.resolveModelAlias('gpt-5.3-codex')).toBe('gpt-5.2-codex');
+    expect(fetcher.getPricing('gpt-5.3-codex')?.inputPer1MUsd).toBeCloseTo(1.5, 10);
   });
 
   it('matches provider-prefixed LiteLLM keys from bare model names', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temporary alias support for GPT-5.3-Codex model that falls back to GPT-5.2-Codex pricing when direct upstream pricing is unavailable.
  * Restored support for the Anthropic Claude Sonnet 4.6 model alias.

* **Documentation**
  * Updated pricing documentation explaining the temporary GPT-5.3-Codex fallback mechanism and its usage conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->