### PR TITLE
fix(render): align efficiency table within terminal width

### DIFF
--- a/src/render/render-efficiency-report.ts
+++ b/src/render/render-efficiency-report.ts
@@ -123,14 +123,20 @@ function resolveWrappedCells(
   let wrappedBodyRows = bodyRows.map((row) => [...row]);
 
   for (let columnIndex = 0; columnIndex < widths.length; columnIndex += 1) {
+    const columnWidth = widths[columnIndex] ?? 0;
+
+    if (columnWidth <= 0) {
+      continue;
+    }
+
     wrappedHeaderCells =
       wrapTableColumn([wrappedHeaderCells], {
         columnIndex,
-        width: widths[columnIndex],
+        width: columnWidth,
       })[0] ?? [];
     wrappedBodyRows = wrapTableColumn(wrappedBodyRows, {
       columnIndex,
-      width: widths[columnIndex],
+      width: columnWidth,
     });
   }
 

--- a/tests/render/render-efficiency-report.test.ts
+++ b/tests/render/render-efficiency-report.test.ts
@@ -4,7 +4,7 @@ import { renderEfficiencyReport } from '../../src/render/render-efficiency-repor
 import type { EfficiencyDataResult } from '../../src/cli/usage-data-contracts.js';
 import { visibleWidth } from '../../src/render/table-text-layout.js';
 
-let pendingStdoutRestores = new Set<() => void>();
+const pendingStdoutRestores = new Set<() => void>();
 
 function overrideStdoutProperty<Key extends 'isTTY' | 'columns'>(
   property: Key,
@@ -124,7 +124,7 @@ describe('renderEfficiencyReport', () => {
     for (const restore of pendingStdoutRestores) {
       restore();
     }
-    pendingStdoutRestores = new Set<() => void>();
+    pendingStdoutRestores.clear();
   });
 
   it('renders markdown output with efficiency columns', () => {


### PR DESCRIPTION
## Summary
- fit efficiency terminal table to the active TTY width before rendering
- shrink and wrap columns to avoid terminal soft-wrap breaking separators
- add regression coverage to assert rendered table lines stay within TTY width

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Efficiency reports now auto-fit and wrap table columns to match your terminal width for improved readability; markdown and JSON outputs remain unchanged.

* **Tests**
  * Added tests that verify terminal table output respects simulated terminal column widths and that terminal stdout/TTY state is properly restored after tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->