### PR TITLE
fix(codex): prevent duplicate token_count double counting

### DIFF
--- a/src/cli/parse-file-cache.ts
+++ b/src/cli/parse-file-cache.ts
@@ -11,7 +11,7 @@ import { normalizeSkippedRowReasons } from './normalize-skipped-row-reasons.js';
 import { asRecord } from '../utils/as-record.js';
 import { getUserCacheRootDir } from '../utils/cache-root-dir.js';
 
-const PARSE_FILE_CACHE_VERSION = 3;
+const PARSE_FILE_CACHE_VERSION = 4;
 const CACHE_KEY_SEPARATOR = '\u0000';
 
 export type ParseFileFingerprint = {

--- a/src/sources/codex/codex-source-adapter.ts
+++ b/src/sources/codex/codex-source-adapter.ts
@@ -111,6 +111,18 @@ function deriveDeltaUsage(
   const totalUsage = toUsage(info.total_token_usage);
   const lastUsage = toUsage(info.last_token_usage);
 
+  if (totalUsage && previousTotalUsage) {
+    const deltaFromTotals = subtractUsage(totalUsage, previousTotalUsage);
+
+    if (hasUsageSignal(deltaFromTotals)) {
+      return { deltaUsage: deltaFromTotals, latestTotalUsage: totalUsage };
+    }
+
+    // Duplicate token_count rows can repeat the last per-turn usage while totals stay unchanged.
+    // Prefer totals and treat unchanged totals as no new usage signal.
+    return { latestTotalUsage: totalUsage };
+  }
+
   if (lastUsage) {
     return { deltaUsage: lastUsage, latestTotalUsage: totalUsage };
   }

--- a/tests/cli/parse-file-cache.test.ts
+++ b/tests/cli/parse-file-cache.test.ts
@@ -218,7 +218,7 @@ describe('ParseFileCache', () => {
     await writeFile(
       cacheFilePath,
       JSON.stringify({
-        version: 3,
+        version: 4,
         entries: [
           {
             source: 'CODEX',
@@ -314,7 +314,7 @@ describe('ParseFileCache', () => {
       version: number;
       entries: unknown[];
     };
-    expect(persisted).toEqual({ version: 3, entries: [] });
+    expect(persisted).toEqual({ version: 4, entries: [] });
   });
 
   it('handles unsupported cache versions by resetting payload on persist', async () => {
@@ -338,7 +338,7 @@ describe('ParseFileCache', () => {
       version: number;
       entries: unknown[];
     };
-    expect(persisted).toEqual({ version: 3, entries: [] });
+    expect(persisted).toEqual({ version: 4, entries: [] });
   });
 
   it('bounds persisted payload by max entries and max bytes', async () => {
@@ -408,7 +408,7 @@ describe('ParseFileCache', () => {
     await writeFile(
       cacheFilePath,
       JSON.stringify({
-        version: 3,
+        version: 4,
         entries: [
           {
             source: 'codex',

--- a/tests/sources/codex-source-adapter.test.ts
+++ b/tests/sources/codex-source-adapter.test.ts
@@ -160,6 +160,96 @@ describe('CodexSourceAdapter', () => {
     expect(events.every((event) => event.repoRoot === '/tmp/codex-repo')).toBe(true);
   });
 
+  it('does not double count duplicated token_count lines when totals do not advance', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'codex-source-dedup-last-usage-'));
+    tempDirs.push(root);
+
+    const filePath = path.join(root, 'session.jsonl');
+
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          timestamp: '2026-02-14T10:00:00.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'codex-dedup',
+            model_provider: 'openai',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-02-14T10:00:01.000Z',
+          type: 'turn_context',
+          payload: { model: 'gpt-5.2-codex' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-02-14T10:00:02.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'token_count',
+            info: {
+              total_token_usage: {
+                input_tokens: 100,
+                cached_input_tokens: 20,
+                output_tokens: 30,
+                reasoning_output_tokens: 5,
+                total_tokens: 130,
+              },
+              last_token_usage: {
+                input_tokens: 100,
+                cached_input_tokens: 20,
+                output_tokens: 30,
+                reasoning_output_tokens: 5,
+                total_tokens: 130,
+              },
+            },
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-02-14T10:00:03.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'token_count',
+            info: {
+              total_token_usage: {
+                input_tokens: 100,
+                cached_input_tokens: 20,
+                output_tokens: 30,
+                reasoning_output_tokens: 5,
+                total_tokens: 130,
+              },
+              last_token_usage: {
+                input_tokens: 100,
+                cached_input_tokens: 20,
+                output_tokens: 30,
+                reasoning_output_tokens: 5,
+                total_tokens: 130,
+              },
+            },
+          },
+        }),
+      ].join('\n'),
+      'utf8',
+    );
+
+    const adapter = new CodexSourceAdapter({ sessionsDir: root });
+    const events = await adapter.parseFile(filePath);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      source: 'codex',
+      sessionId: 'codex-dedup',
+      provider: 'openai',
+      model: 'gpt-5.2-codex',
+      inputTokens: 80,
+      cacheReadTokens: 20,
+      outputTokens: 30,
+      reasoningTokens: 5,
+      totalTokens: 130,
+      costMode: 'estimated',
+    });
+  });
+
   it('uses legacy model fallback when no model metadata exists', async () => {
     const fixturePath = path.resolve('tests/fixtures/codex/session-legacy-model.jsonl');
     const adapter = new CodexSourceAdapter();


### PR DESCRIPTION
## Summary
- prevent Codex duplicate token_count rows from being counted twice when cumulative totals have not advanced
- prefer cumulative total deltas when prior totals exist
- bump parse-file cache version to 4 to invalidate stale cached diagnostics
- add regression test for duplicate Codex token rows

## Validation
- pnpm run lint
- pnpm run typecheck
- pnpm run test
- pnpm run format:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate token counting that occurred when usage totals remained unchanged between consecutive entries, ensuring accurate usage reporting.
* **Chores**
  * Cache format updated; existing cached data will be automatically refreshed on next run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->