### PR TITLE
feat: share SVG redesign + efficiency metric fix + landing page

### DIFF
--- a/src/render/render-efficiency-share-svg.ts
+++ b/src/render/render-efficiency-share-svg.ts
@@ -85,7 +85,7 @@ function renderCommitBarLabels(
     .map((row, i) => {
       const x = chartLeft + i * stepX;
       const yTop = scaleY(row.commitCount, maxCommits, chartTop, chartBottom);
-      return `<text x="${x.toFixed(2)}" y="${(yTop - 8).toFixed(0)}" text-anchor="middle" font-size="12" font-weight="600" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">${formatInteger(row.commitCount)}</text>`;
+      return `<text x="${x.toFixed(2)}" y="${(yTop - 8).toFixed(0)}" text-anchor="middle" font-size="12" font-weight="600" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">${escapeSvg(formatInteger(row.commitCount))}</text>`;
     })
     .join('\n');
 }

--- a/src/render/render-usage-share-svg.ts
+++ b/src/render/render-usage-share-svg.ts
@@ -75,15 +75,9 @@ function buildStackedValues(series: SourceSeries[]): number[][] {
   return stacked;
 }
 
-/** Thin gradient accent strip at the SVG top edge. */
+/** Thin gradient accent strip at the SVG top edge (gradient defined in main defs). */
 function renderAccentBar(): string {
-  return [
-    `<defs><linearGradient id="accent-grad" x1="0" y1="0" x2="1" y2="0">`,
-    `  <stop offset="0%" stop-color="#10b981"/>`,
-    `  <stop offset="100%" stop-color="#06b6d4"/>`,
-    `</linearGradient></defs>`,
-    `<rect width="${W}" height="${ACCENT_H}" fill="url(#accent-grad)"/>`,
-  ].join('\n');
+  return `<rect width="${W}" height="${ACCENT_H}" fill="url(#accent-grad)"/>`;
 }
 
 /** Left-side stat column: big token count + cost. */
@@ -339,6 +333,10 @@ export function renderUsageShareSvg(
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
+  <linearGradient id="accent-grad" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0%" stop-color="#10b981"/>
+    <stop offset="100%" stop-color="#06b6d4"/>
+  </linearGradient>
   <clipPath id="chart-clip">
     <rect x="${chartLeft}" y="${chartTop - 4}" width="${chartW}" height="${chartH + 8}"/>
   </clipPath>


### PR DESCRIPTION
## Summary

### Share SVG Redesign
- Dark-theme design system with shared tokens (`share-svg-theme.ts`)
- Green→cyan gradient accent bar + `llm-usage-metrics` footer strip (brand identity)
- **Usage SVG**: stacked area chart with gradient fills, source pills, stat column, dot markers
- **Efficiency SVG**: simplified to 2 metrics (commit bars + $/commit line), inline data labels, clear dual-axis labels
- **Optimize SVG**: heatmap with accent bar + footer branding
- Wired `--share` flag to all usage commands (daily/weekly/monthly)

### Efficiency Metric Fix
- `tokensPerCommit` now uses `(input + output + reasoning) / commits` — excludes cache tokens
- Previously included cache read tokens (95% of total), inflating the metric ~20x
- Dropped redundant `All Tokens/Commit` column (16 cols → 15 effective change)

### Landing Page Redesign
- Modern dark/light design with hero, terminal preview, speed comparison, scroll animations
- `IntersectionObserver`-based reveal animations

### Review Fixes
- Consolidated duplicate `<defs>` block in usage SVG
- Separated actual/scale max for axis labels (shows $0.00 not $0.01 when all values zero)
- Deterministic source ordering via `.sort(compareByCodePoint)`
- Extracted chart colors to constants
- Added spy cleanup in test finally blocks

## Validation
```
pnpm run lint        ✅
pnpm run typecheck   ✅  
pnpm run test        ✅ 558 passed
pnpm run format:check ✅
pnpm run build       ✅
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of commit count labels to properly display special characters.

* **Refactor**
  * Optimized gradient rendering structure in visualization components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->