### PR TITLE
fix(cli): stop waiting on detached share opener

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,10 +7,9 @@ import { loadPackageMetadataFromRuntime } from './package-metadata.js';
 
 const { packageName, packageVersion } = loadPackageMetadataFromRuntime();
 const updateRuntimeConfig = getUpdateNotifierRuntimeConfig();
-
 const cli = createCli({ version: packageVersion });
 
-try {
+async function main(): Promise<void> {
   const updateResult = await checkForUpdatesAndMaybeRestart({
     packageName,
     currentVersion: packageVersion,
@@ -23,8 +22,10 @@ try {
   } else {
     await cli.parseAsync(process.argv);
   }
-} catch (error) {
+}
+
+main().catch((error: unknown) => {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
   process.exitCode = 1;
-}
+});

--- a/src/cli/share-artifact.ts
+++ b/src/cli/share-artifact.ts
@@ -57,7 +57,7 @@ async function spawnDetached(command: string, args: string[]): Promise<void> {
 
     const cleanup = (): void => {
       child.removeListener('error', onError);
-      child.removeListener('close', onClose);
+      child.removeListener('spawn', onSpawn);
     };
 
     const onError = (error: Error): void => {
@@ -65,22 +65,14 @@ async function spawnDetached(command: string, args: string[]): Promise<void> {
       reject(error);
     };
 
-    const onClose = (code: number | null): void => {
+    const onSpawn = (): void => {
       cleanup();
-      if (code === 0) {
-        resolve();
-        return;
-      }
-
-      const exitCode = code === null ? 'null' : String(code);
-      reject(new Error(`Failed to open SVG with "${command}" (exit code: ${exitCode})`));
+      child.unref();
+      resolve();
     };
 
     child.once('error', onError);
-    child.once('close', onClose);
-    child.once('spawn', () => {
-      child.unref();
-    });
+    child.once('spawn', onSpawn);
   });
 }
 

--- a/tests/cli/share-artifact-spawn.test.ts
+++ b/tests/cli/share-artifact-spawn.test.ts
@@ -58,7 +58,7 @@ function createMockChildProcess(): {
 }
 
 describe('share-artifact spawn integration', () => {
-  it('resolves only when opener exits successfully', async () => {
+  it('resolves as soon as the opener process spawns successfully', async () => {
     const { child, emit, unrefSpy, removeListenerSpy } = createMockChildProcess();
     spawnMock.mockReturnValueOnce(child);
 
@@ -66,7 +66,6 @@ describe('share-artifact spawn integration', () => {
       platform: 'darwin',
     });
     emit('spawn');
-    emit('close', 0);
     await openPromise;
 
     expect(spawnMock).toHaveBeenCalledWith('open', ['/tmp/share.svg'], {
@@ -77,7 +76,7 @@ describe('share-artifact spawn integration', () => {
     expect(unrefSpy).toHaveBeenCalledTimes(1);
     expect(removeListenerSpy).toHaveBeenCalledTimes(2);
     expect(removeListenerSpy).toHaveBeenNthCalledWith(1, 'error', expect.any(Function));
-    expect(removeListenerSpy).toHaveBeenNthCalledWith(2, 'close', expect.any(Function));
+    expect(removeListenerSpy).toHaveBeenNthCalledWith(2, 'spawn', expect.any(Function));
   });
 
   it('rejects when spawn emits error', async () => {
@@ -93,7 +92,7 @@ describe('share-artifact spawn integration', () => {
     expect(removeListenerSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('rejects when opener exits with non-zero code', async () => {
+  it('ignores close after a successful spawn because the process is detached', async () => {
     const { child, emit, removeListenerSpy } = createMockChildProcess();
     spawnMock.mockReturnValueOnce(child);
 
@@ -103,7 +102,7 @@ describe('share-artifact spawn integration', () => {
     emit('spawn');
     emit('close', 3);
 
-    await expect(openPromise).rejects.toThrow('Failed to open SVG with "xdg-open" (exit code: 3)');
+    await expect(openPromise).resolves.toBeUndefined();
     expect(removeListenerSpy).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- stop awaiting the detached share opener's exit and resolve once the opener process spawns
- wrap the CLI entrypoint in an explicit async main function instead of using top-level await
- update detached opener regression coverage to match the runtime behavior

## Validation
- pnpm run cli monthly --share
- pnpm exec vitest run tests/cli/share-artifact.test.ts tests/cli/share-artifact-spawn.test.ts
- pnpm run lint
- pnpm run typecheck
- pnpm run test
- pnpm run format:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling flow in CLI initialization.
  * Simplified spawn process resolution timing for artifact sharing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->