### PR TITLE
docs: align landing, caching, and sidebar with current sources

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -72,6 +72,7 @@ export default defineConfig({
             { label: 'gemini', link: '/sources/gemini/' },
             { label: 'droid', link: '/sources/droid/' },
             { label: 'opencode', link: '/sources/opencode/' },
+            { label: 'claude', link: '/sources/claude/' },
           ],
         },
         {

--- a/site/src/content/docs/caching.mdx
+++ b/site/src/content/docs/caching.mdx
@@ -26,7 +26,7 @@ On Linux with no `XDG_CACHE_HOME`, `<platform-cache-root>` defaults to `~/.cache
 ### 1) Update-check cache
 
 - read cached npm version if still fresh
-- otherwise continue immediately and refresh the cache in a detached background process
+- otherwise perform a bounded fetch (default 1s timeout) for the latest version so the update prompt stays consistent across commands
 - on fetch failure, fallback to previous cached version when available
 - optional session-scoped mode creates a per-shell cache file
 - skipped entirely for `--help`, `--version`, `npx`, and direct source/development runs

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ tableOfContents: false
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-Welcome to the `llm-usage-metrics` documentation. This high-performance CLI tool provides deep visibility into your local AI development costs by aggregating usage across pi, codex, Gemini CLI, Droid CLI, and OpenCode sessions.
+Welcome to the `llm-usage-metrics` documentation. This high-performance CLI tool provides deep visibility into your local AI development costs by aggregating usage across pi, codex, Gemini CLI, Droid CLI, OpenCode, and Claude Code sessions.
 
 ## Quick Navigation
 
@@ -43,7 +43,7 @@ Welcome to the `llm-usage-metrics` documentation. This high-performance CLI tool
   />
   <LinkCard
     title="Data Sources"
-    description="Technical details on pi, codex, Gemini CLI, Droid CLI, and OpenCode adapters."
+    description="Technical details on pi, codex, Gemini CLI, Droid CLI, OpenCode, and Claude Code adapters."
     href="/llm-usage-metrics/sources/"
   />
   <LinkCard
@@ -62,7 +62,7 @@ Welcome to the `llm-usage-metrics` documentation. This high-performance CLI tool
 
 `llm-usage-metrics` is built for engineers who need precise, local-first auditing of their AI workflows:
 
-- **Universal Parsing**: Autonomously discovers and parses `.pi`, `.codex`, `.gemini`, `.factory`, and OpenCode session data.
+- **Universal Parsing**: Autonomously discovers and parses `.pi`, `.codex`, `.gemini`, `.factory`, OpenCode, and `.claude` session data.
   OpenCode parsing requires Node.js 24+ with built-in `node:sqlite`.
 - **LiteLLM Integration**: Applies real-time pricing models to local events for accurate USD estimation.
 - **Git Attribution**: Optionally joins usage with local Git history to derive true ROI metrics (Cost per Commit, Tokens per Line).


### PR DESCRIPTION
## What

Documentation pass to align all user-facing docs with the current project state, framed as the always-present current state.

## Changes

- **Landing page (`index.mdx`)** — the intro line and the Data Sources LinkCard now list Claude Code alongside pi, codex, Gemini CLI, Droid CLI, and OpenCode. The engine-overview "Universal Parsing" bullet includes `.claude` session data.
- **Caching (`caching.mdx`)** — the update-check cache section describes the bounded synchronous fetch (default 1s timeout) that keeps the update prompt consistent across commands, replacing the previous description of a detached background refresh (that behavior was removed).
- **Sidebar (`astro.config.mjs`)** — adds the `claude` source page so it is reachable from the docs navigation. The `claude.mdx` page already existed but was not linked.

## Verification

- Regenerated `cli-reference.mdx` from the CLI (no drift; already current).
- Swept all docs for stale source lists, removed-feature references (`anthropic-api`, `ANTHROPIC_ADMIN_KEY`, detached background refresh, `LLM_USAGE_REFRESH_UPDATE_CHECK`) — clean.
- `pnpm --filter llm-usage-metrics-site check` — 0 errors / 0 warnings / 0 hints
- `pnpm --filter llm-usage-metrics-site build` — 22 pages built
- `pnpm run lint` / `pnpm run typecheck` / `prettier --check` (changed files) — green

## Scope

No code changes. The README, per-source pages, configuration, efficiency, optimize, trends, output-formats, pricing, troubleshooting, architecture, benchmarks, security, CONTRIBUTING, and `docs/` repo docs were reviewed and are already current.