### PR TITLE
feat(source): add OpenClaw adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 
 ---
 
-Aggregate token usage and costs from your local coding agent sessions. Supports **pi**, **codex**, **Gemini CLI**, **Droid CLI**, and **OpenCode** with zero configuration required.
+Aggregate token usage and costs from your local coding agent sessions. Supports **pi**, **codex**, **Gemini CLI**, **Droid CLI**, **OpenCode**, **OpenClaw**, and **Claude Code** with zero configuration required.
 
 ## ✨ Features
 
-- **Zero-Config Discovery** — Automatically finds `.pi`, `.codex`, `.gemini`, `.factory`, and OpenCode session data
+- **Zero-Config Discovery** — Automatically finds `.pi`, `.codex`, `.gemini`, `.factory`, OpenCode, OpenClaw, and Claude session data
 - **LiteLLM Pricing** — Real-time pricing sync with offline caching support
 - **Flexible Reports** — Daily, weekly, and monthly aggregations
 - **Efficiency Reports** — Correlate cost/tokens with repository commit outcomes
@@ -62,6 +62,7 @@ llm-usage daily
 | **Gemini CLI**  | `~/.gemini/tmp/*/chats/*.json`           | Automatic                        |
 | **Droid CLI**   | `~/.factory/sessions/**/*.settings.json` | Automatic                        |
 | **OpenCode**    | `~/.opencode/opencode.db`                | Auto or explicit `--opencode-db` |
+| **OpenClaw**    | `~/.openclaw/agents/**/*.jsonl`          | Automatic                        |
 | **Claude Code** | `~/.claude/projects/**/*.jsonl`          | Automatic                        |
 
 OpenCode source support requires Node.js 24+ runtime with built-in `node:sqlite`.
@@ -155,6 +156,7 @@ llm-usage efficiency monthly --repo-dir /path/to/repo --source codex
 llm-usage efficiency monthly --repo-dir /path/to/repo --source gemini
 llm-usage efficiency monthly --repo-dir /path/to/repo --source droid
 llm-usage efficiency monthly --repo-dir /path/to/repo --source opencode
+llm-usage efficiency monthly --repo-dir /path/to/repo --source openclaw
 llm-usage efficiency monthly --repo-dir /path/to/repo --source claude
 ```
 
@@ -179,7 +181,7 @@ llm-usage optimize monthly --provider openai --candidate-model gpt-4.1 --candida
 
 ```bash
 # By source
-llm-usage monthly --source pi,codex,gemini,droid,claude
+llm-usage monthly --source pi,codex,gemini,droid,openclaw,claude
 
 # By provider
 llm-usage monthly --provider openai
@@ -191,13 +193,13 @@ llm-usage monthly --model claude
 llm-usage monthly --source opencode --provider openai --model gpt-4.1
 ```
 
-Use `--source` to scope where events came from (`pi`, `codex`, `gemini`, `droid`, `opencode`, `claude`), and `--provider` to scope the billing entity behind those events.
+Use `--source` to scope where events came from (`pi`, `codex`, `gemini`, `droid`, `opencode`, `openclaw`, `claude`), and `--provider` to scope the billing entity behind those events.
 
 ### Custom Paths
 
 ```bash
 # Custom directories
-llm-usage daily --source-dir pi=/path/to/pi --source-dir codex=/path/to/codex --source-dir gemini=/path/to/.gemini --source-dir droid=/path/to/.factory/sessions --source-dir claude=/path/to/.claude/projects
+llm-usage daily --source-dir pi=/path/to/pi --source-dir codex=/path/to/codex --source-dir gemini=/path/to/.gemini --source-dir droid=/path/to/.factory/sessions --source-dir openclaw=/path/to/.openclaw/agents --source-dir claude=/path/to/.claude/projects
 
 # Explicit Gemini/Droid/Claude/OpenCode paths
 llm-usage daily --gemini-dir /path/to/.gemini

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-usage-metrics",
   "version": "0.7.1",
-  "description": "CLI for aggregating local LLM usage metrics from pi, codex, gemini, droid, opencode, and claude sessions",
+  "description": "CLI for aggregating local LLM usage metrics from pi, codex, gemini, droid, opencode, openclaw, and claude sessions",
   "type": "module",
   "packageManager": "pnpm@10.17.1",
   "engines": {
@@ -47,6 +47,7 @@
     "droid",
     "factory",
     "opencode",
+    "openclaw",
     "claude"
   ],
   "license": "MIT",

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
     starlight({
       title: 'llm-usage-metrics',
       description:
-        'CLI for aggregating local LLM usage metrics from pi, codex, gemini, droid, and opencode sessions',
+        'CLI for aggregating local LLM usage metrics from pi, codex, gemini, droid, opencode, openclaw, and claude sessions',
       favicon: '/favicon.svg',
       logo: {
         src: './src/assets/logo.svg',
@@ -72,6 +72,7 @@ export default defineConfig({
             { label: 'gemini', link: '/sources/gemini/' },
             { label: 'droid', link: '/sources/droid/' },
             { label: 'opencode', link: '/sources/opencode/' },
+            { label: 'openclaw', link: '/sources/openclaw/' },
             { label: 'claude', link: '/sources/claude/' },
           ],
         },

--- a/site/src/content/docs/cli-reference.mdx
+++ b/site/src/content/docs/cli-reference.mdx
@@ -52,7 +52,7 @@ Generated from root + command help output.
 | `--repo-dir` | - | `<path>` | Path to repository for Git outcome metrics \(efficiency only\) |
 | `--share` | - | - | Write a share SVG image to the current directory \(daily, weekly, monthly, efficiency, optimize only\) |
 | `--since` | - | `<YYYY-MM-DD>` | Inclusive start date filter |
-| `--source` | - | `<name>` | Filter by source id \(repeatable or comma-separated, supported sources \(6\): pi, codex, gemini, droid, opencode, claude\) |
+| `--source` | - | `<name>` | Filter by source id \(repeatable or comma-separated, supported sources \(7\): pi, codex, gemini, droid, opencode, openclaw, claude\) |
 | `--source-dir` | - | `<source-id=path>` | Override source directory for directory-backed sources \(repeatable\) |
 | `--timezone` | - | `<iana>` | Timezone for bucketing \(default: local system timezone\) |
 | `--top` | - | `<n>` | Show only the top N cheapest candidates \(positive integer\) \(optimize only\) |
@@ -64,7 +64,7 @@ Generated from root + command help output.
 
 ```bash
 llm-usage daily
-llm-usage daily --source-dir pi=/tmp/pi-sessions --source-dir gemini=/tmp/.gemini --source-dir droid=/tmp/droid-sessions
+llm-usage daily --source-dir pi=/tmp/pi-sessions --source-dir gemini=/tmp/.gemini --source-dir droid=/tmp/droid-sessions --source-dir openclaw=/tmp/openclaw-agents
 llm-usage daily --json
 llm-usage daily --markdown
 llm-usage weekly --timezone Europe/Paris

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -16,7 +16,7 @@ llm-usage daily --pi-dir /path/to/pi --codex-dir /path/to/codex --gemini-dir /pa
 Generic directory override syntax:
 
 ```bash
-llm-usage daily --source-dir pi=/path/to/pi --source-dir codex=/path/to/codex --source-dir gemini=/path/to/.gemini --source-dir droid=/path/to/.factory/sessions --source-dir claude=/path/to/.claude/projects
+llm-usage daily --source-dir pi=/path/to/pi --source-dir codex=/path/to/codex --source-dir gemini=/path/to/.gemini --source-dir droid=/path/to/.factory/sessions --source-dir openclaw=/path/to/.openclaw/agents --source-dir claude=/path/to/.claude/projects
 ```
 
 OpenCode uses a dedicated DB override flag:
@@ -27,7 +27,7 @@ llm-usage daily --opencode-db /path/to/opencode.db
 
 Notes:
 
-- `--source-dir` supports directory-backed sources (`pi`, `codex`, `gemini`, `droid`, `claude`).
+- `--source-dir` supports directory-backed sources (`pi`, `codex`, `gemini`, `droid`, `openclaw`, `claude`).
 - `--source-dir opencode=...` is rejected; use `--opencode-db`.
 - OpenCode path precedence is:
   1. `--opencode-db`
@@ -40,6 +40,7 @@ llm-usage monthly --source pi
 llm-usage monthly --source pi,codex
 llm-usage monthly --source droid --droid-dir /path/to/.factory/sessions
 llm-usage monthly --source opencode --opencode-db /path/to/opencode.db
+llm-usage monthly --source openclaw --source-dir openclaw=/path/to/.openclaw/agents
 llm-usage monthly --source claude --claude-dir /path/to/.claude/projects
 ```
 

--- a/site/src/content/docs/efficiency.mdx
+++ b/site/src/content/docs/efficiency.mdx
@@ -86,6 +86,7 @@ llm-usage efficiency monthly --repo-dir /path/to/repo --source codex
 llm-usage efficiency monthly --repo-dir /path/to/repo --source gemini
 llm-usage efficiency monthly --repo-dir /path/to/repo --source droid
 llm-usage efficiency monthly --repo-dir /path/to/repo --source opencode
+llm-usage efficiency monthly --repo-dir /path/to/repo --source openclaw
 llm-usage efficiency monthly --repo-dir /path/to/repo --source claude
 ```
 

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -24,6 +24,7 @@ npx --yes llm-usage-metrics@latest daily
   - `.gemini` sessions (`~/.gemini/tmp/*/chats/*.json`)
   - Droid sessions (`~/.factory/sessions/**/*.settings.json`)
   - OpenCode SQLite DB (auto-discovered or explicit `--opencode-db`, requires built-in `node:sqlite` support)
+  - OpenClaw transcripts (`~/.openclaw/agents/**/*.jsonl`)
   - Claude Code projects (`~/.claude/projects/**/*.jsonl`)
 
 ## First report
@@ -43,7 +44,7 @@ llm-usage trends --metric tokens --days 14
 ## Common filters
 
 ```bash
-llm-usage monthly --source pi,codex,gemini,droid,claude
+llm-usage monthly --source pi,codex,gemini,droid,openclaw,claude
 llm-usage monthly --provider openai
 llm-usage monthly --model claude
 ```

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ tableOfContents: false
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-Welcome to the `llm-usage-metrics` documentation. This high-performance CLI tool provides deep visibility into your local AI development costs by aggregating usage across pi, codex, Gemini CLI, Droid CLI, OpenCode, and Claude Code sessions.
+Welcome to the `llm-usage-metrics` documentation. This high-performance CLI tool provides deep visibility into your local AI development costs by aggregating usage across pi, codex, Gemini CLI, Droid CLI, OpenCode, OpenClaw, and Claude Code sessions.
 
 ## Quick Navigation
 
@@ -43,7 +43,7 @@ Welcome to the `llm-usage-metrics` documentation. This high-performance CLI tool
   />
   <LinkCard
     title="Data Sources"
-    description="Technical details on pi, codex, Gemini CLI, Droid CLI, OpenCode, and Claude Code adapters."
+    description="Technical details on pi, codex, Gemini CLI, Droid CLI, OpenCode, OpenClaw, and Claude Code adapters."
     href="/llm-usage-metrics/sources/"
   />
   <LinkCard
@@ -62,7 +62,7 @@ Welcome to the `llm-usage-metrics` documentation. This high-performance CLI tool
 
 `llm-usage-metrics` is built for engineers who need precise, local-first auditing of their AI workflows:
 
-- **Universal Parsing**: Autonomously discovers and parses `.pi`, `.codex`, `.gemini`, `.factory`, OpenCode, and `.claude` session data.
+- **Universal Parsing**: Autonomously discovers and parses `.pi`, `.codex`, `.gemini`, `.factory`, OpenCode, OpenClaw, and `.claude` session data.
   OpenCode parsing requires Node.js 24+ with built-in `node:sqlite`.
 - **LiteLLM Integration**: Applies real-time pricing models to local events for accurate USD estimation.
 - **Git Attribution**: Optionally joins usage with local Git history to derive true ROI metrics (Cost per Commit, Tokens per Line).

--- a/site/src/content/docs/sources/index.mdx
+++ b/site/src/content/docs/sources/index.mdx
@@ -2,13 +2,14 @@
 title: Data Sources
 ---
 
-`llm-usage-metrics` supports six built-in sources:
+`llm-usage-metrics` supports seven built-in sources:
 
 - `pi`
 - `codex`
 - `gemini`
 - `droid`
 - `opencode`
+- `openclaw`
 - `claude`
 
 Each source is parsed by a dedicated adapter and normalized into the same `UsageEvent` schema before pricing/aggregation.
@@ -19,16 +20,18 @@ Each source is parsed by a dedicated adapter and normalized into the same `Usage
 - `gemini`: JSON session discovery under `~/.gemini/tmp/*/chats/*.json` (or `--gemini-dir`)
 - `droid`: session settings discovery under `~/.factory/sessions/**/*.settings.json` (or `--droid-dir`)
 - `opencode`: single SQLite DB (auto-discovered or explicit `--opencode-db`)
+- `openclaw`: recursive JSONL discovery under `~/.openclaw/agents/**/*.jsonl`
 - `claude`: recursive JSONL discovery under `~/.claude/projects/**/*.jsonl` (or `--claude-dir`)
 
 ## Source filtering
 
 ```bash
 llm-usage monthly --source pi
-llm-usage monthly --source pi,codex,gemini,droid,claude
+llm-usage monthly --source pi,codex,gemini,droid,openclaw,claude
 llm-usage monthly --source gemini --gemini-dir /path/to/.gemini
 llm-usage monthly --source droid --droid-dir /path/to/.factory/sessions
 llm-usage monthly --source opencode --opencode-db /path/to/opencode.db
+llm-usage monthly --source openclaw --source-dir openclaw=/path/to/.openclaw/agents
 llm-usage monthly --source claude --claude-dir /path/to/.claude/projects
 ```
 

--- a/site/src/content/docs/sources/openclaw.mdx
+++ b/site/src/content/docs/sources/openclaw.mdx
@@ -1,0 +1,22 @@
+---
+title: openclaw Source
+---
+
+The `openclaw` adapter reads OpenClaw agent transcripts:
+
+- `~/.openclaw/agents/**/*.jsonl`
+
+```bash
+llm-usage daily --source openclaw
+llm-usage daily --source-dir openclaw=/path/to/.openclaw/agents
+```
+
+## Parsing behavior
+
+- Reads transcript JSONL rows recursively in deterministic path order.
+- Uses `session` rows for `sessionId`, timestamp, and `cwd`.
+- Tracks provider/model changes as later transcript rows update runtime state.
+- Emits only assistant messages with usage.
+- Preserves explicit `usage.cost` values when present.
+- Falls back to file mtime when an assistant usage row has no message timestamp.
+- Ignores non-usage user/system/tool rows and OpenClaw delivery-mirror assistant rows.

--- a/site/src/content/docs/troubleshooting.mdx
+++ b/site/src/content/docs/troubleshooting.mdx
@@ -13,6 +13,7 @@ llm-usage daily --source codex
 llm-usage daily --source gemini
 llm-usage daily --source droid
 llm-usage daily --source opencode
+llm-usage daily --source openclaw
 llm-usage daily --source claude
 ```
 
@@ -28,14 +29,14 @@ OpenCode parsing requires Node.js 24+ runtime with built-in `node:sqlite`.
 
 ## Path override errors
 
-- `--source-dir` supports only `pi`, `codex`, `gemini`, `droid`, and `claude`.
+- `--source-dir` supports only `pi`, `codex`, `gemini`, `droid`, `openclaw`, and `claude`.
 - `--pi-dir`, `--codex-dir`, `--gemini-dir`, `--droid-dir`, and `--claude-dir` must point to valid directories.
 - For OpenCode, use `--opencode-db`.
 
 Correct examples:
 
 ```bash
-llm-usage daily --source-dir pi=/path/to/pi --source-dir codex=/path/to/codex --source-dir gemini=/path/to/.gemini --source-dir droid=/path/to/.factory/sessions --source-dir claude=/path/to/.claude/projects
+llm-usage daily --source-dir pi=/path/to/pi --source-dir codex=/path/to/codex --source-dir gemini=/path/to/.gemini --source-dir droid=/path/to/.factory/sessions --source-dir openclaw=/path/to/.openclaw/agents --source-dir claude=/path/to/.claude/projects
 llm-usage daily --pi-dir /path/to/pi --codex-dir /path/to/codex --gemini-dir /path/to/.gemini --droid-dir /path/to/.factory/sessions --claude-dir /path/to/.claude/projects
 llm-usage daily --opencode-db /path/to/opencode.db
 ```

--- a/src/cli/report-definitions/report-definitions.ts
+++ b/src/cli/report-definitions/report-definitions.ts
@@ -61,7 +61,7 @@ function createUsageReportDefinition(granularity: ReportGranularity): ReportRunt
       },
       {
         command:
-          'llm-usage daily --source-dir pi=/tmp/pi-sessions --source-dir gemini=/tmp/.gemini --source-dir droid=/tmp/droid-sessions',
+          'llm-usage daily --source-dir pi=/tmp/pi-sessions --source-dir gemini=/tmp/.gemini --source-dir droid=/tmp/droid-sessions --source-dir openclaw=/tmp/openclaw-agents',
         includeInRootHelp: true,
         includeInCliReference: true,
       },

--- a/src/sources/create-default-adapters.ts
+++ b/src/sources/create-default-adapters.ts
@@ -3,6 +3,7 @@ import { CodexSourceAdapter } from './codex/codex-source-adapter.js';
 import { DroidSourceAdapter } from './droid/droid-source-adapter.js';
 import { GeminiSourceAdapter } from './gemini/gemini-source-adapter.js';
 import { OpenCodeSourceAdapter } from './opencode/opencode-source-adapter.js';
+import { OpenClawSourceAdapter } from './openclaw/openclaw-source-adapter.js';
 import { PiSourceAdapter } from './pi/pi-source-adapter.js';
 import type { SourceAdapter } from './source-adapter.js';
 import { compareByCodePoint } from '../utils/compare-by-code-point.js';
@@ -95,6 +96,22 @@ const sourceRegistrations: readonly SourceRegistration[] = [
       new OpenCodeSourceAdapter({
         dbPath: options.opencodeDb,
       }),
+  },
+  {
+    id: 'openclaw',
+    sourceDirOverride: { kind: 'directory' },
+    create: (_options, sourceDirectoryOverrides) => {
+      const directoryConfig = resolveDirectoryConfig(
+        'openclaw',
+        undefined,
+        sourceDirectoryOverrides,
+      );
+
+      return new OpenClawSourceAdapter({
+        agentsDir: directoryConfig.path,
+        requireAgentsDir: directoryConfig.requireExistingPath,
+      });
+    },
   },
   {
     id: 'claude',

--- a/src/sources/openclaw/openclaw-source-adapter.ts
+++ b/src/sources/openclaw/openclaw-source-adapter.ts
@@ -341,19 +341,35 @@ export class OpenClawSourceAdapter implements SourceAdapter {
         continue;
       }
 
-      const provider =
-        firstText(line.provider, message.provider, line.modelProvider, message.modelProvider) ??
-        state.provider;
-      const model =
-        firstText(line.model, message.model, line.modelId, message.modelId) ?? state.model;
+      const rowProvider = firstText(
+        line.provider,
+        message.provider,
+        line.modelProvider,
+        message.modelProvider,
+        line.model_provider,
+        message.model_provider,
+      );
+      const rowModel = firstText(
+        line.model,
+        message.model,
+        line.modelId,
+        message.modelId,
+        line.model_id,
+        message.model_id,
+      );
 
-      // Delivery-mirror rows carry their own openclaw/delivery-mirror markers; skip
-      // them before touching runtime state so they never overwrite the real provider/model.
-      if (isDeliveryMirror(provider, model, message)) {
+      // Delivery-mirror rows carry their own openclaw/delivery-mirror markers, so
+      // detect them from row-local values only (state-inherited values would both
+      // miss real usage after a mirror row and drop real usage in openclaw-provider
+      // sessions), and skip them before touching runtime state.
+      if (isDeliveryMirror(rowProvider, rowModel, message)) {
         continue;
       }
 
       updateRuntimeStateFromRecord(state, line, message);
+
+      const provider = rowProvider ?? state.provider;
+      const model = rowModel ?? state.model;
 
       const usage = extractUsage(line, message);
 

--- a/src/sources/openclaw/openclaw-source-adapter.ts
+++ b/src/sources/openclaw/openclaw-source-adapter.ts
@@ -1,0 +1,403 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { createUsageEvent } from '../../domain/usage-event.js';
+import type { UsageEvent } from '../../domain/usage-event.js';
+import type { NumberLike } from '../../domain/normalization.js';
+import { asRecord } from '../../utils/as-record.js';
+import { compareByCodePoint } from '../../utils/compare-by-code-point.js';
+import { discoverJsonlFiles } from '../../utils/discover-jsonl-files.js';
+import { pathStat } from '../../utils/fs-helpers.js';
+import { readJsonlObjects } from '../../utils/read-jsonl-objects.js';
+import {
+  asTrimmedText,
+  isBlankText,
+  normalizeTimestampCandidate,
+  toNumberLike,
+} from '../parsing-utils.js';
+import type { SourceAdapter, SourceParseFileDiagnostics } from '../source-adapter.js';
+
+const defaultAgentsDir = path.join(os.homedir(), '.openclaw', 'agents');
+
+type OpenClawSessionState = {
+  sessionId: string;
+  sessionTimestamp?: string;
+  repoRoot?: string;
+  provider?: string;
+  model?: string;
+};
+
+type OpenClawUsageExtract = {
+  inputTokens?: NumberLike;
+  outputTokens?: NumberLike;
+  reasoningTokens?: NumberLike;
+  cacheReadTokens?: NumberLike;
+  cacheWriteTokens?: NumberLike;
+  totalTokens?: NumberLike;
+  costUsd?: NumberLike;
+};
+
+type SkippedRowReason = 'invalid_usage_event';
+
+export type OpenClawSourceAdapterOptions = {
+  agentsDir?: string;
+  requireAgentsDir?: boolean;
+};
+
+const SESSION_LINE_PATTERN = /"type"\s*:\s*"session"/u;
+const MESSAGE_LINE_PATTERN = /"type"\s*:\s*"message"/u;
+const MODEL_CHANGE_LINE_PATTERN = /"type"\s*:\s*"model_change"/u;
+const USAGE_LINE_PATTERN = /"usage"\s*:/u;
+const MODEL_LINE_PATTERN = /"model"\s*:/u;
+const PROVIDER_LINE_PATTERN = /"provider"\s*:/u;
+
+function shouldParseOpenClawJsonlLine(lineText: string): boolean {
+  return (
+    SESSION_LINE_PATTERN.test(lineText) ||
+    MESSAGE_LINE_PATTERN.test(lineText) ||
+    MODEL_CHANGE_LINE_PATTERN.test(lineText) ||
+    USAGE_LINE_PATTERN.test(lineText) ||
+    MODEL_LINE_PATTERN.test(lineText) ||
+    PROVIDER_LINE_PATTERN.test(lineText)
+  );
+}
+
+function getFallbackSessionId(filePath: string): string {
+  return path.basename(filePath, '.jsonl');
+}
+
+function resolveRepoRootFromRecord(
+  record: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  const pathRecord = asRecord(record.path);
+
+  return (
+    asTrimmedText(record.cwd) ??
+    asTrimmedText(pathRecord?.root) ??
+    asTrimmedText(pathRecord?.cwd) ??
+    asTrimmedText(record.repo_root) ??
+    asTrimmedText(record.repoRoot) ??
+    asTrimmedText(record.project_root) ??
+    asTrimmedText(record.projectRoot) ??
+    asTrimmedText(record.workspace)
+  );
+}
+
+function firstText(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const normalized = asTrimmedText(value);
+
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return undefined;
+}
+
+function isAssistantMessage(
+  line: Record<string, unknown>,
+  message: Record<string, unknown>,
+): boolean {
+  return firstText(line.role, message.role)?.toLowerCase() === 'assistant';
+}
+
+function isDeliveryMirror(
+  provider: string | undefined,
+  model: string | undefined,
+  message: Record<string, unknown>,
+): boolean {
+  const messageKind = firstText(message.kind, message.source, message.provenance);
+  return (
+    provider?.toLowerCase() === 'openclaw' ||
+    model?.toLowerCase() === 'delivery-mirror' ||
+    messageKind?.toLowerCase() === 'delivery-mirror'
+  );
+}
+
+function toFiniteNumber(value: NumberLike | undefined): number | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string' && value.trim().length === 0) {
+    return undefined;
+  }
+
+  const parsed = typeof value === 'number' ? value : Number(value);
+
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function extractCostUsd(usage: Record<string, unknown>): NumberLike {
+  const cost = asRecord(usage.cost);
+
+  return (
+    toNumberLike(usage.costUsd) ??
+    toNumberLike(usage.cost_usd) ??
+    toNumberLike(usage.turnUsd) ??
+    toNumberLike(usage.turn_usd) ??
+    toNumberLike(usage.usd) ??
+    toNumberLike(usage.cost) ??
+    toNumberLike(cost?.total) ??
+    toNumberLike(cost?.usd) ??
+    toNumberLike(cost?.turnUsd) ??
+    toNumberLike(cost?.turn_usd)
+  );
+}
+
+function extractUsageFromRecord(usage: Record<string, unknown>): OpenClawUsageExtract | undefined {
+  const extracted: OpenClawUsageExtract = {
+    inputTokens:
+      toNumberLike(usage.input) ??
+      toNumberLike(usage.inputTokens) ??
+      toNumberLike(usage.input_tokens) ??
+      toNumberLike(usage.prompt_tokens),
+    outputTokens:
+      toNumberLike(usage.output) ??
+      toNumberLike(usage.outputTokens) ??
+      toNumberLike(usage.output_tokens) ??
+      toNumberLike(usage.completion_tokens),
+    reasoningTokens:
+      toNumberLike(usage.reasoning) ??
+      toNumberLike(usage.reasoningTokens) ??
+      toNumberLike(usage.reasoning_tokens) ??
+      toNumberLike(usage.reasoningOutput) ??
+      toNumberLike(usage.reasoning_output_tokens),
+    cacheReadTokens:
+      toNumberLike(usage.cacheRead) ??
+      toNumberLike(usage.cache_read) ??
+      toNumberLike(usage.cacheReadTokens) ??
+      toNumberLike(usage.cache_read_tokens) ??
+      toNumberLike(usage.cached) ??
+      toNumberLike(usage.cached_input_tokens),
+    cacheWriteTokens:
+      toNumberLike(usage.cacheWrite) ??
+      toNumberLike(usage.cache_write) ??
+      toNumberLike(usage.cacheWriteTokens) ??
+      toNumberLike(usage.cache_write_tokens),
+    totalTokens:
+      toNumberLike(usage.total) ??
+      toNumberLike(usage.totalTokens) ??
+      toNumberLike(usage.total_tokens),
+    costUsd: extractCostUsd(usage),
+  };
+
+  const usageCandidates = [
+    extracted.inputTokens,
+    extracted.outputTokens,
+    extracted.reasoningTokens,
+    extracted.cacheReadTokens,
+    extracted.cacheWriteTokens,
+    extracted.totalTokens,
+  ];
+  const hasPositiveUsageSignal = usageCandidates.some((value) => {
+    const parsed = toFiniteNumber(value);
+    return parsed !== undefined && parsed > 0;
+  });
+  const explicitCost = toFiniteNumber(extracted.costUsd);
+  const hasPositiveCostSignal = explicitCost !== undefined && explicitCost > 0;
+
+  return hasPositiveUsageSignal || hasPositiveCostSignal ? extracted : undefined;
+}
+
+function mergeUsageExtracts(
+  primary: OpenClawUsageExtract | undefined,
+  fallback: OpenClawUsageExtract | undefined,
+): OpenClawUsageExtract | undefined {
+  if (!primary) {
+    return fallback;
+  }
+
+  if (!fallback) {
+    return primary;
+  }
+
+  return {
+    inputTokens: primary.inputTokens ?? fallback.inputTokens,
+    outputTokens: primary.outputTokens ?? fallback.outputTokens,
+    reasoningTokens: primary.reasoningTokens ?? fallback.reasoningTokens,
+    cacheReadTokens: primary.cacheReadTokens ?? fallback.cacheReadTokens,
+    cacheWriteTokens: primary.cacheWriteTokens ?? fallback.cacheWriteTokens,
+    totalTokens: primary.totalTokens ?? fallback.totalTokens,
+    costUsd: primary.costUsd ?? fallback.costUsd,
+  };
+}
+
+function extractUsage(line: Record<string, unknown>, message: Record<string, unknown>) {
+  const lineUsage = asRecord(line.usage);
+  const messageUsage = asRecord(message.usage);
+  const extractedLineUsage = lineUsage ? extractUsageFromRecord(lineUsage) : undefined;
+  const extractedMessageUsage = messageUsage ? extractUsageFromRecord(messageUsage) : undefined;
+
+  return mergeUsageExtracts(extractedLineUsage, extractedMessageUsage);
+}
+
+function resolveTimestamp(
+  line: Record<string, unknown>,
+  message: Record<string, unknown>,
+  state: OpenClawSessionState,
+  fallbackTimestamp: string | undefined,
+): string | undefined {
+  const candidates = [line.timestamp, message.timestamp, fallbackTimestamp, state.sessionTimestamp];
+
+  for (const candidate of candidates) {
+    const normalizedTimestamp = normalizeTimestampCandidate(candidate);
+
+    if (normalizedTimestamp) {
+      return normalizedTimestamp;
+    }
+  }
+
+  return undefined;
+}
+
+function updateRuntimeStateFromRecord(
+  state: OpenClawSessionState,
+  record: Record<string, unknown>,
+  nested: Record<string, unknown> | undefined,
+): void {
+  state.provider =
+    firstText(record.provider, record.modelProvider, record.model_provider, nested?.provider) ??
+    state.provider;
+  state.model =
+    firstText(record.model, record.modelId, record.model_id, nested?.model, nested?.modelId) ??
+    state.model;
+  state.repoRoot =
+    resolveRepoRootFromRecord(record) ?? resolveRepoRootFromRecord(nested) ?? state.repoRoot;
+}
+
+export class OpenClawSourceAdapter implements SourceAdapter {
+  public readonly id = 'openclaw' as const;
+
+  private readonly agentsDir: string;
+  private readonly requireAgentsDir: boolean;
+
+  public constructor(options: OpenClawSourceAdapterOptions = {}) {
+    this.agentsDir = options.agentsDir ?? defaultAgentsDir;
+    this.requireAgentsDir = options.requireAgentsDir ?? false;
+  }
+
+  public async discoverFiles(): Promise<string[]> {
+    if (isBlankText(this.agentsDir)) {
+      throw new Error('OpenClaw agents directory must be a non-empty path');
+    }
+
+    const normalizedAgentsDir = this.agentsDir.trim();
+
+    if (this.requireAgentsDir) {
+      const agentsDirStats = await pathStat(normalizedAgentsDir);
+
+      if (!agentsDirStats) {
+        throw new Error(
+          `OpenClaw agents directory is missing or unreadable: ${normalizedAgentsDir}`,
+        );
+      }
+
+      if (!agentsDirStats.isDirectory()) {
+        throw new Error(`OpenClaw agents directory is not a directory: ${normalizedAgentsDir}`);
+      }
+    }
+
+    return discoverJsonlFiles(normalizedAgentsDir);
+  }
+
+  public async parseFile(filePath: string): Promise<UsageEvent[]> {
+    return (await this.parseFileWithDiagnostics(filePath)).events;
+  }
+
+  public async parseFileWithDiagnostics(filePath: string): Promise<SourceParseFileDiagnostics> {
+    const events: UsageEvent[] = [];
+    let skippedRows = 0;
+    const skippedRowReasons = new Map<SkippedRowReason, number>();
+    const recordSkippedRow = (reason: SkippedRowReason): void => {
+      skippedRows += 1;
+      skippedRowReasons.set(reason, (skippedRowReasons.get(reason) ?? 0) + 1);
+    };
+    const fileStats = await pathStat(filePath);
+    const fallbackTimestamp = fileStats?.mtime.toISOString();
+    const state: OpenClawSessionState = {
+      sessionId: getFallbackSessionId(filePath),
+    };
+
+    for await (const line of readJsonlObjects(filePath, {
+      shouldParseLine: shouldParseOpenClawJsonlLine,
+    })) {
+      const message = asRecord(line.message) ?? line;
+
+      if (line.type === 'session') {
+        state.sessionId = firstText(line.id, line.sessionId, line.session_id) ?? state.sessionId;
+        state.sessionTimestamp =
+          normalizeTimestampCandidate(line.timestamp) ?? state.sessionTimestamp;
+        updateRuntimeStateFromRecord(state, line, message);
+        continue;
+      }
+
+      if (line.type === 'model_change') {
+        updateRuntimeStateFromRecord(state, line, message);
+        continue;
+      }
+
+      updateRuntimeStateFromRecord(state, line, message);
+
+      if (line.type !== 'message' || !isAssistantMessage(line, message)) {
+        continue;
+      }
+
+      const usage = extractUsage(line, message);
+
+      if (!usage) {
+        continue;
+      }
+
+      const provider =
+        firstText(line.provider, message.provider, line.modelProvider, message.modelProvider) ??
+        state.provider;
+      const model =
+        firstText(line.model, message.model, line.modelId, message.modelId) ?? state.model;
+
+      if (isDeliveryMirror(provider, model, message)) {
+        continue;
+      }
+
+      const timestamp = resolveTimestamp(line, message, state, fallbackTimestamp);
+
+      if (!timestamp) {
+        continue;
+      }
+
+      try {
+        events.push(
+          createUsageEvent({
+            source: this.id,
+            sessionId: state.sessionId,
+            timestamp,
+            repoRoot: state.repoRoot,
+            provider,
+            model,
+            ...usage,
+          }),
+        );
+      } catch {
+        recordSkippedRow('invalid_usage_event');
+        continue;
+      }
+    }
+
+    return {
+      events,
+      skippedRows,
+      skippedRowReasons: [...skippedRowReasons.entries()]
+        .map(([reason, count]) => ({ reason, count }))
+        .sort((left, right) => compareByCodePoint(left.reason, right.reason)),
+    };
+  }
+}
+
+export function getDefaultOpenClawAgentsDir(): string {
+  return defaultAgentsDir;
+}

--- a/src/sources/openclaw/openclaw-source-adapter.ts
+++ b/src/sources/openclaw/openclaw-source-adapter.ts
@@ -260,11 +260,23 @@ function updateRuntimeStateFromRecord(
   nested: Record<string, unknown> | undefined,
 ): void {
   state.provider =
-    firstText(record.provider, record.modelProvider, record.model_provider, nested?.provider) ??
-    state.provider;
+    firstText(
+      record.provider,
+      record.modelProvider,
+      record.model_provider,
+      nested?.provider,
+      nested?.modelProvider,
+      nested?.model_provider,
+    ) ?? state.provider;
   state.model =
-    firstText(record.model, record.modelId, record.model_id, nested?.model, nested?.modelId) ??
-    state.model;
+    firstText(
+      record.model,
+      record.modelId,
+      record.model_id,
+      nested?.model,
+      nested?.modelId,
+      nested?.model_id,
+    ) ?? state.model;
   state.repoRoot =
     resolveRepoRootFromRecord(record) ?? resolveRepoRootFromRecord(nested) ?? state.repoRoot;
 }

--- a/src/sources/openclaw/openclaw-source-adapter.ts
+++ b/src/sources/openclaw/openclaw-source-adapter.ts
@@ -5,10 +5,10 @@ import { createUsageEvent } from '../../domain/usage-event.js';
 import type { UsageEvent } from '../../domain/usage-event.js';
 import type { NumberLike } from '../../domain/normalization.js';
 import { asRecord } from '../../utils/as-record.js';
-import { compareByCodePoint } from '../../utils/compare-by-code-point.js';
 import { discoverJsonlFiles } from '../../utils/discover-jsonl-files.js';
 import { pathStat } from '../../utils/fs-helpers.js';
 import { readJsonlObjects } from '../../utils/read-jsonl-objects.js';
+import { incrementSkippedReason, toParseDiagnostics } from '../parse-diagnostics.js';
 import {
   asTrimmedText,
   isBlankText,
@@ -36,8 +36,6 @@ type OpenClawUsageExtract = {
   totalTokens?: NumberLike;
   costUsd?: NumberLike;
 };
-
-type SkippedRowReason = 'invalid_usage_event';
 
 export type OpenClawSourceAdapterOptions = {
   agentsDir?: string;
@@ -313,11 +311,7 @@ export class OpenClawSourceAdapter implements SourceAdapter {
   public async parseFileWithDiagnostics(filePath: string): Promise<SourceParseFileDiagnostics> {
     const events: UsageEvent[] = [];
     let skippedRows = 0;
-    const skippedRowReasons = new Map<SkippedRowReason, number>();
-    const recordSkippedRow = (reason: SkippedRowReason): void => {
-      skippedRows += 1;
-      skippedRowReasons.set(reason, (skippedRowReasons.get(reason) ?? 0) + 1);
-    };
+    const skippedRowReasons = new Map<string, number>();
     const fileStats = await pathStat(filePath);
     const fallbackTimestamp = fileStats?.mtime.toISOString();
     const state: OpenClawSessionState = {
@@ -342,15 +336,8 @@ export class OpenClawSourceAdapter implements SourceAdapter {
         continue;
       }
 
-      updateRuntimeStateFromRecord(state, line, message);
-
       if (line.type !== 'message' || !isAssistantMessage(line, message)) {
-        continue;
-      }
-
-      const usage = extractUsage(line, message);
-
-      if (!usage) {
+        updateRuntimeStateFromRecord(state, line, message);
         continue;
       }
 
@@ -360,7 +347,17 @@ export class OpenClawSourceAdapter implements SourceAdapter {
       const model =
         firstText(line.model, message.model, line.modelId, message.modelId) ?? state.model;
 
+      // Delivery-mirror rows carry their own openclaw/delivery-mirror markers; skip
+      // them before touching runtime state so they never overwrite the real provider/model.
       if (isDeliveryMirror(provider, model, message)) {
+        continue;
+      }
+
+      updateRuntimeStateFromRecord(state, line, message);
+
+      const usage = extractUsage(line, message);
+
+      if (!usage) {
         continue;
       }
 
@@ -383,18 +380,13 @@ export class OpenClawSourceAdapter implements SourceAdapter {
           }),
         );
       } catch {
-        recordSkippedRow('invalid_usage_event');
+        skippedRows += 1;
+        incrementSkippedReason(skippedRowReasons, 'invalid_usage_event');
         continue;
       }
     }
 
-    return {
-      events,
-      skippedRows,
-      skippedRowReasons: [...skippedRowReasons.entries()]
-        .map(([reason, count]) => ({ reason, count }))
-        .sort((left, right) => compareByCodePoint(left.reason, right.reason)),
-    };
+    return toParseDiagnostics(events, skippedRows, skippedRowReasons);
   }
 }
 

--- a/tests/cli/create-cli.test.ts
+++ b/tests/cli/create-cli.test.ts
@@ -143,7 +143,7 @@ describe('createCli', () => {
     const compactDailyCommandHelp = dailyCommandHelp?.replace(/\s+/gu, ' ');
 
     expect(compactHelp).toContain(
-      'Supported sources (6): pi, codex, gemini, droid, opencode, claude',
+      'Supported sources (7): pi, codex, gemini, droid, opencode, openclaw, claude',
     );
     expect(compactHelp).toContain('Show daily usage report');
     expect(compactHelp).toContain('llm-usage <command> --help');

--- a/tests/cli/run-usage-report.test.ts
+++ b/tests/cli/run-usage-report.test.ts
@@ -416,7 +416,7 @@ describe('buildUsageReport', () => {
         source: 'unknown-source',
       }),
     ).rejects.toThrow(
-      'Unknown --source value(s): unknown-source. Allowed values: claude, codex, droid, gemini, opencode, pi',
+      'Unknown --source value(s): unknown-source. Allowed values: claude, codex, droid, gemini, openclaw, opencode, pi',
     );
 
     await expect(

--- a/tests/e2e/usage-report.e2e.test.ts
+++ b/tests/e2e/usage-report.e2e.test.ts
@@ -6,6 +6,7 @@ import { buildUsageReport } from '../../src/cli/run-usage-report.js';
 
 const piDir = path.resolve('tests/fixtures/e2e/pi');
 const codexDir = path.resolve('tests/fixtures/e2e/codex');
+const openclawDir = path.resolve('tests/fixtures/e2e/openclaw');
 
 describe('usage report e2e', () => {
   it('renders daily report with mixed pi + codex data', async () => {
@@ -54,5 +55,17 @@ describe('usage report e2e', () => {
     expect(rows.some((row) => row.periodKey === '2026-01')).toBe(true);
     expect(rows.some((row) => row.periodKey === '2026-02')).toBe(true);
     expect(rows.at(-1)).toMatchObject({ periodKey: 'ALL', rowType: 'grand_total' });
+  });
+
+  it('renders daily report from openclaw source-dir override', async () => {
+    const report = await buildUsageReport('daily', {
+      source: 'openclaw',
+      sourceDir: [`openclaw=${openclawDir}`],
+      timezone: 'UTC',
+    });
+
+    expect(report).toContain('2026-05-01');
+    expect(report).toContain('openclaw');
+    expect(report).toContain('TOTAL');
   });
 });

--- a/tests/fixtures/e2e/openclaw/session.jsonl
+++ b/tests/fixtures/e2e/openclaw/session.jsonl
@@ -1,0 +1,2 @@
+{"type":"session","id":"openclaw-e2e","cwd":"/tmp/openclaw-e2e","timestamp":"2026-05-01T00:00:00.000Z","provider":"anthropic","model":"claude-sonnet-4-6"}
+{"type":"message","id":"a1","role":"assistant","timestamp":"2026-05-01T12:00:00.000Z","usage":{"input":10,"output":5,"total":15,"cost":{"total":0.001}}}

--- a/tests/fixtures/openclaw/session-mixed.jsonl
+++ b/tests/fixtures/openclaw/session-mixed.jsonl
@@ -1,0 +1,10 @@
+{"type":"session","id":"openclaw-session-1","cwd":"/tmp/openclaw-repo","timestamp":"2026-04-01T10:00:00.000Z","provider":"anthropic","model":"claude-sonnet-4-6"}
+{"type":"message","id":"u1","parentId":"root","role":"user","timestamp":"2026-04-01T10:00:10.000Z","message":{"role":"user","content":"hello"}}
+{"type":"message","id":"a1","parentId":"u1","role":"assistant","timestamp":"2026-04-01T10:00:20.000Z","usage":{"input":100,"output":20,"reasoning":5,"cacheRead":10,"cacheWrite":3,"total":133,"cost":{"total":0.0123}}}
+{"type":"model_change","provider":"openai","model":"gpt-5.3-codex","cwd":"/tmp/openclaw-repo-2"}
+{"type":"message","id":"a2","parentId":"u1","message":{"role":"assistant","timestamp":"2026-04-01T10:01:00.000Z","usage":{"input_tokens":7,"output_tokens":11,"reasoning_output_tokens":2,"cached_input_tokens":5,"total_tokens":25,"cost_usd":0.0042}}}
+{"type":"message","id":"mirror","role":"assistant","timestamp":"2026-04-01T10:01:30.000Z","provider":"openclaw","model":"delivery-mirror","usage":{"input":999,"output":999,"total":1998,"cost":{"total":9.99}}}
+{"type":"custom","id":"state","provider":"google","model":"gemini-3-pro"}
+{"type":"message","id":"a3","role":"assistant","usage":{"input":3,"output":4,"total":7}}
+{"type":"message","id":"a4","role":"assistant","timestamp":"2026-04-01T10:02:00.000Z"}
+{"type":"message","id":"tool","role":"toolResult","timestamp":"2026-04-01T10:02:10.000Z","usage":{"input":1,"output":1,"total":2}}

--- a/tests/sources/create-default-adapters.test.ts
+++ b/tests/sources/create-default-adapters.test.ts
@@ -23,6 +23,7 @@ describe('createDefaultAdapters', () => {
       'gemini',
       'droid',
       'opencode',
+      'openclaw',
       'claude',
     ]);
   });
@@ -48,7 +49,17 @@ describe('createDefaultAdapters', () => {
     const claudeTempDir = await mkdtemp(
       path.join(os.tmpdir(), 'usage-adapters-claude-source-dir-'),
     );
-    tempDirs.push(piTempDir, codexTempDir, geminiTempDir, droidTempDir, claudeTempDir);
+    const openclawTempDir = await mkdtemp(
+      path.join(os.tmpdir(), 'usage-adapters-openclaw-source-dir-'),
+    );
+    tempDirs.push(
+      piTempDir,
+      codexTempDir,
+      geminiTempDir,
+      droidTempDir,
+      claudeTempDir,
+      openclawTempDir,
+    );
 
     const piFile = path.join(piTempDir, 'pi-session.jsonl');
     const codexFile = path.join(codexTempDir, 'codex-session.jsonl');
@@ -57,12 +68,14 @@ describe('createDefaultAdapters', () => {
     const geminiFile = path.join(geminiChatsDir, 'session.json');
     const droidFile = path.join(droidTempDir, 'droid-session.settings.json');
     const claudeFile = path.join(claudeTempDir, 'claude-session.jsonl');
+    const openclawFile = path.join(openclawTempDir, 'openclaw-session.jsonl');
 
     await writeFile(piFile, '{}\n', 'utf8');
     await writeFile(codexFile, '{}\n', 'utf8');
     await writeFile(geminiFile, '{}', 'utf8');
     await writeFile(droidFile, '{}', 'utf8');
     await writeFile(claudeFile, '{}\n', 'utf8');
+    await writeFile(openclawFile, '{}\n', 'utf8');
 
     const adapters = createDefaultAdapters({
       sourceDir: [
@@ -71,6 +84,7 @@ describe('createDefaultAdapters', () => {
         `gemini=${geminiTempDir}`,
         `droid=${droidTempDir}`,
         `claude=${claudeTempDir}`,
+        `openclaw=${openclawTempDir}`,
       ],
     });
 
@@ -78,7 +92,8 @@ describe('createDefaultAdapters', () => {
     await expect(adapters[1].discoverFiles()).resolves.toEqual([await realpath(codexFile)]);
     await expect(adapters[2].discoverFiles()).resolves.toEqual([await realpath(geminiFile)]);
     await expect(adapters[3].discoverFiles()).resolves.toEqual([await realpath(droidFile)]);
-    await expect(adapters[5].discoverFiles()).resolves.toEqual([await realpath(claudeFile)]);
+    await expect(adapters[5].discoverFiles()).resolves.toEqual([await realpath(openclawFile)]);
+    await expect(adapters[6].discoverFiles()).resolves.toEqual([await realpath(claudeFile)]);
   });
 
   it('throws on invalid source directory override entries', () => {
@@ -263,6 +278,17 @@ describe('createDefaultAdapters', () => {
 
     await expect(claudeAdapter?.discoverFiles()).rejects.toThrow(
       'Claude projects directory is missing or unreadable',
+    );
+  });
+
+  it('fails openclaw discovery when an explicitly configured directory is missing', async () => {
+    const adapters = createDefaultAdapters({
+      sourceDir: [`openclaw=${path.join(os.tmpdir(), `missing-openclaw-${Date.now()}`)}`],
+    });
+    const openclawAdapter = adapters.find((adapter) => adapter.id === 'openclaw');
+
+    await expect(openclawAdapter?.discoverFiles()).rejects.toThrow(
+      'OpenClaw agents directory is missing or unreadable',
     );
   });
 });

--- a/tests/sources/openclaw-source-adapter.test.ts
+++ b/tests/sources/openclaw-source-adapter.test.ts
@@ -140,6 +140,55 @@ describe('OpenClawSourceAdapter', () => {
     });
   });
 
+  it('keeps assistant usage that inherits state after a delivery-mirror row', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-mirror-state-'));
+    tempDirs.push(root);
+
+    const filePath = path.join(root, 'session.jsonl');
+
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          type: 'session',
+          id: 'openclaw-mirror-state',
+          timestamp: '2026-04-05T20:00:00.000Z',
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+        }),
+        JSON.stringify({
+          type: 'message',
+          id: 'mirror',
+          role: 'assistant',
+          timestamp: '2026-04-05T20:01:00.000Z',
+          provider: 'openclaw',
+          model: 'delivery-mirror',
+          usage: { input: 999, output: 999, total: 1998, cost: { total: 9.99 } },
+        }),
+        JSON.stringify({
+          type: 'message',
+          id: 'real',
+          role: 'assistant',
+          timestamp: '2026-04-05T20:02:00.000Z',
+          usage: { input: 10, output: 5, total: 15 },
+        }),
+      ].join('\n'),
+      'utf8',
+    );
+
+    const adapter = new OpenClawSourceAdapter({ agentsDir: root });
+    const events = await adapter.parseFile(filePath);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    });
+  });
+
   it('merges line-level tokens with nested message cost', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-merged-usage-'));
     tempDirs.push(root);

--- a/tests/sources/openclaw-source-adapter.test.ts
+++ b/tests/sources/openclaw-source-adapter.test.ts
@@ -189,6 +189,81 @@ describe('OpenClawSourceAdapter', () => {
     });
   });
 
+  it('attributes snake_case model_provider/model_id aliases to the row itself', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-snake-aliases-'));
+    tempDirs.push(root);
+
+    const filePath = path.join(root, 'session.jsonl');
+
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          type: 'session',
+          id: 'openclaw-snake-aliases',
+          timestamp: '2026-04-06T20:00:00.000Z',
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+        }),
+        JSON.stringify({
+          type: 'message',
+          role: 'assistant',
+          timestamp: '2026-04-06T20:01:00.000Z',
+          model_provider: 'openai',
+          model_id: 'gpt-5.3-codex',
+          usage: { input: 10, output: 5, total: 15 },
+        }),
+      ].join('\n'),
+      'utf8',
+    );
+
+    const adapter = new OpenClawSourceAdapter({ agentsDir: root });
+    const events = await adapter.parseFile(filePath);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      provider: 'openai',
+      model: 'gpt-5.3-codex',
+    });
+  });
+
+  it('keeps real usage when the session provider is openclaw', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-gateway-provider-'));
+    tempDirs.push(root);
+
+    const filePath = path.join(root, 'session.jsonl');
+
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          type: 'session',
+          id: 'openclaw-gateway-provider',
+          timestamp: '2026-04-07T20:00:00.000Z',
+          provider: 'openclaw',
+          model: 'claude-sonnet-4-6',
+        }),
+        JSON.stringify({
+          type: 'message',
+          role: 'assistant',
+          timestamp: '2026-04-07T20:01:00.000Z',
+          usage: { input: 10, output: 5, total: 15 },
+        }),
+      ].join('\n'),
+      'utf8',
+    );
+
+    const adapter = new OpenClawSourceAdapter({ agentsDir: root });
+    const events = await adapter.parseFile(filePath);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      provider: 'openclaw',
+      model: 'claude-sonnet-4-6',
+      totalTokens: 15,
+    });
+  });
+
   it('merges line-level tokens with nested message cost', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-merged-usage-'));
     tempDirs.push(root);

--- a/tests/sources/openclaw-source-adapter.test.ts
+++ b/tests/sources/openclaw-source-adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, realpath, rm, utimes, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, mkdtemp, realpath, rm, utimes, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -40,7 +40,12 @@ describe('OpenClawSourceAdapter', () => {
   });
 
   it('parses assistant usage while tracking provider and model changes', async () => {
-    const fixturePath = path.resolve('tests/fixtures/openclaw/session-mixed.jsonl');
+    const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-session-mixed-'));
+    tempDirs.push(root);
+
+    // Copy the fixture so the mtime tweak never touches the checked-in file.
+    const fixturePath = path.join(root, 'session-mixed.jsonl');
+    await copyFile(path.resolve('tests/fixtures/openclaw/session-mixed.jsonl'), fixturePath);
     const fileMtime = new Date('2026-04-01T10:03:00.000Z');
     await utimes(fixturePath, fileMtime, fileMtime);
 
@@ -213,6 +218,22 @@ describe('OpenClawSourceAdapter', () => {
           model_id: 'gpt-5.3-codex',
           usage: { input: 10, output: 5, total: 15 },
         }),
+        JSON.stringify({
+          type: 'message',
+          timestamp: '2026-04-06T20:02:00.000Z',
+          message: {
+            role: 'assistant',
+            model_provider: 'google',
+            model_id: 'gemini-3-pro',
+            usage: { input: 6, output: 2, total: 8 },
+          },
+        }),
+        JSON.stringify({
+          type: 'message',
+          role: 'assistant',
+          timestamp: '2026-04-06T20:03:00.000Z',
+          usage: { input: 3, output: 1, total: 4 },
+        }),
       ].join('\n'),
       'utf8',
     );
@@ -220,10 +241,19 @@ describe('OpenClawSourceAdapter', () => {
     const adapter = new OpenClawSourceAdapter({ agentsDir: root });
     const events = await adapter.parseFile(filePath);
 
-    expect(events).toHaveLength(1);
+    expect(events).toHaveLength(3);
     expect(events[0]).toMatchObject({
       provider: 'openai',
       model: 'gpt-5.3-codex',
+    });
+    expect(events[1]).toMatchObject({
+      provider: 'google',
+      model: 'gemini-3-pro',
+    });
+    // The bare row inherits the nested snake_case aliases through runtime state.
+    expect(events[2]).toMatchObject({
+      provider: 'google',
+      model: 'gemini-3-pro',
     });
   });
 

--- a/tests/sources/openclaw-source-adapter.test.ts
+++ b/tests/sources/openclaw-source-adapter.test.ts
@@ -1,0 +1,258 @@
+import { mkdir, mkdtemp, realpath, rm, utimes, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  getDefaultOpenClawAgentsDir,
+  OpenClawSourceAdapter,
+} from '../../src/sources/openclaw/openclaw-source-adapter.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+describe('OpenClawSourceAdapter', () => {
+  it('discovers jsonl files recursively in deterministic order', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-source-adapter-'));
+    tempDirs.push(root);
+
+    const nested = path.join(root, 'main', 'sessions');
+    await mkdir(nested, { recursive: true });
+
+    const first = path.join(root, 'a.jsonl');
+    const second = path.join(nested, 'b.jsonl');
+
+    await writeFile(path.join(root, 'ignore.txt'), 'noop', 'utf8');
+    await writeFile(second, '{}\n', 'utf8');
+    await writeFile(first, '{}\n', 'utf8');
+
+    const adapter = new OpenClawSourceAdapter({ agentsDir: root });
+
+    await expect(adapter.discoverFiles()).resolves.toEqual([
+      await realpath(first),
+      await realpath(second),
+    ]);
+  });
+
+  it('parses assistant usage while tracking provider and model changes', async () => {
+    const fixturePath = path.resolve('tests/fixtures/openclaw/session-mixed.jsonl');
+    const fileMtime = new Date('2026-04-01T10:03:00.000Z');
+    await utimes(fixturePath, fileMtime, fileMtime);
+
+    const adapter = new OpenClawSourceAdapter();
+    const events = await adapter.parseFile(fixturePath);
+
+    expect(events).toHaveLength(3);
+    expect(events[0]).toMatchObject({
+      source: 'openclaw',
+      sessionId: 'openclaw-session-1',
+      repoRoot: '/tmp/openclaw-repo',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      inputTokens: 100,
+      outputTokens: 20,
+      reasoningTokens: 5,
+      cacheReadTokens: 10,
+      cacheWriteTokens: 3,
+      totalTokens: 133,
+      costUsd: 0.0123,
+      costMode: 'explicit',
+    });
+
+    expect(events[1]).toMatchObject({
+      source: 'openclaw',
+      sessionId: 'openclaw-session-1',
+      repoRoot: '/tmp/openclaw-repo-2',
+      provider: 'openai',
+      model: 'gpt-5.3-codex',
+      inputTokens: 7,
+      outputTokens: 11,
+      reasoningTokens: 2,
+      cacheReadTokens: 5,
+      totalTokens: 25,
+      costUsd: 0.0042,
+      costMode: 'explicit',
+    });
+
+    expect(events[2]).toMatchObject({
+      source: 'openclaw',
+      sessionId: 'openclaw-session-1',
+      repoRoot: '/tmp/openclaw-repo-2',
+      provider: 'google',
+      model: 'gemini-3-pro',
+      inputTokens: 3,
+      outputTokens: 4,
+      totalTokens: 7,
+      costMode: 'estimated',
+    });
+    expect(events[2]?.timestamp).toBe('2026-04-01T10:03:00.000Z');
+  });
+
+  it('falls back to message.usage when line-level usage is malformed', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-message-usage-'));
+    tempDirs.push(root);
+
+    const filePath = path.join(root, 'session.jsonl');
+
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          type: 'session',
+          id: 'openclaw-message-usage',
+          timestamp: '2026-04-02T20:00:00.000Z',
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+        }),
+        JSON.stringify({
+          type: 'message',
+          timestamp: '2026-04-02T20:01:00.000Z',
+          usage: 'unexpected-string',
+          message: {
+            role: 'assistant',
+            usage: {
+              input_tokens: 4,
+              output_tokens: 6,
+              total_tokens: 10,
+              cost: 0.006,
+            },
+          },
+        }),
+      ].join('\n'),
+      'utf8',
+    );
+
+    const adapter = new OpenClawSourceAdapter({ agentsDir: root });
+    const events = await adapter.parseFile(filePath);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      inputTokens: 4,
+      outputTokens: 6,
+      totalTokens: 10,
+      costUsd: 0.006,
+      costMode: 'explicit',
+    });
+  });
+
+  it('merges line-level tokens with nested message cost', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-merged-usage-'));
+    tempDirs.push(root);
+
+    const filePath = path.join(root, 'session.jsonl');
+
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          type: 'session',
+          id: 'openclaw-merged-usage',
+          timestamp: '2026-04-03T20:00:00.000Z',
+          provider: 'openai',
+          model: 'gpt-5.3-codex',
+        }),
+        JSON.stringify({
+          type: 'message',
+          role: 'assistant',
+          timestamp: '2026-04-03T20:01:00.000Z',
+          usage: {
+            input: 10,
+            output: 4,
+            total: 14,
+          },
+          message: {
+            usage: {
+              cost: {
+                total: 0.0025,
+              },
+            },
+          },
+        }),
+      ].join('\n'),
+      'utf8',
+    );
+
+    const adapter = new OpenClawSourceAdapter({ agentsDir: root });
+    const events = await adapter.parseFile(filePath);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 4,
+      totalTokens: 14,
+      costUsd: 0.0025,
+      costMode: 'explicit',
+    });
+  });
+
+  it('reports invalid usage events through parse diagnostics', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-invalid-event-'));
+    tempDirs.push(root);
+
+    const filePath = path.join(root, '.jsonl');
+
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        type: 'message',
+        role: 'assistant',
+        timestamp: '2026-04-03T20:01:00.000Z',
+        usage: {
+          input: 10,
+          output: 4,
+          total: 14,
+        },
+      }),
+      'utf8',
+    );
+
+    const adapter = new OpenClawSourceAdapter({ agentsDir: root });
+    Object.defineProperty(adapter, 'id', { value: ' ' });
+    const diagnostics = await adapter.parseFileWithDiagnostics(filePath);
+
+    expect(diagnostics.events).toEqual([]);
+    expect(diagnostics.skippedRows).toBe(1);
+    expect(diagnostics.skippedRowReasons).toEqual([
+      {
+        reason: 'invalid_usage_event',
+        count: 1,
+      },
+    ]);
+  });
+
+  it('fails discovery when an explicitly configured directory is missing', async () => {
+    const adapter = new OpenClawSourceAdapter({
+      agentsDir: path.join(os.tmpdir(), `missing-openclaw-${Date.now()}`),
+      requireAgentsDir: true,
+    });
+
+    await expect(adapter.discoverFiles()).rejects.toThrow(
+      'OpenClaw agents directory is missing or unreadable',
+    );
+  });
+
+  it('fails discovery when an explicitly configured path is a file', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'openclaw-file-path-'));
+    tempDirs.push(root);
+    const filePath = path.join(root, 'session.jsonl');
+    await writeFile(filePath, '{}\n', 'utf8');
+
+    const adapter = new OpenClawSourceAdapter({
+      agentsDir: filePath,
+      requireAgentsDir: true,
+    });
+
+    await expect(adapter.discoverFiles()).rejects.toThrow(
+      `OpenClaw agents directory is not a directory: ${filePath}`,
+    );
+  });
+
+  it('uses the default OpenClaw agents directory', () => {
+    expect(getDefaultOpenClawAgentsDir()).toBe(path.join(os.homedir(), '.openclaw', 'agents'));
+  });
+});


### PR DESCRIPTION
fix [issue-60](https://github.com/ayagmar/llm-usage-metrics/issues/60)

## Summary

Adds **OpenClaw** as a new usage source.

## Changes

- Added an **OpenClaw JSONL** source adapter for `~/.openclaw/agents/**/*.jsonl`
- Emits **assistant usage events only**
- Tracks **provider/model changes**
- Preserves **explicit costs** when available
- Falls back to the **file modification time (mtime)** when event timestamps are missing
- Wired OpenClaw into the source registry and added support for `--source-dir openclaw=...`
- Added parser, source registry, CLI, and end-to-end (E2E) test coverage
- Updated the README and documentation site with OpenClaw source documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenClaw as a supported data source across the CLI and reports.
  * Expanded source discovery and filtering with `--source` and `--source-dir`, including per-source directory mappings for OpenClaw.
* **Documentation**
  * Updated documentation to list OpenClaw in supported sources, CLI examples, configuration, efficiency, troubleshooting, and added a dedicated OpenClaw source guide.
* **Tests**
  * Added/updated unit and end-to-end tests and fixtures to validate OpenClaw discovery, parsing, diagnostics behavior, and `sourceDir` overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->