### PR TITLE
docs(site): refresh branding and product guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,589 +1,208 @@
-<div align="center">
+<p align="center">
+  <img src="https://ayagmar.github.io/llm-usage-metrics/favicon.svg" width="72" height="72" alt="LLM Usage Metrics logo">
+</p>
 
-<img src="https://ayagmar.github.io/llm-usage-metrics/favicon.svg" width="64" height="64" alt="llm-usage-metrics logo">
+<h1 align="center">llm-usage-metrics</h1>
 
-# llm-usage-metrics
+<p align="center">
+  Local usage reports for AI coding tools.
+</p>
 
-**Track and analyze your local LLM usage across coding agents**
+<p align="center">
+  <a href="https://www.npmjs.com/package/llm-usage-metrics"><img src="https://img.shields.io/npm/v/llm-usage-metrics.svg?style=flat-square&color=b65331" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/llm-usage-metrics"><img src="https://img.shields.io/npm/dt/llm-usage-metrics.svg?style=flat-square&color=5f655b" alt="npm downloads"></a>
+  <a href="https://github.com/ayagmar/llm-usage-metrics/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/ayagmar/llm-usage-metrics/ci.yml?style=flat-square&label=CI" alt="CI status"></a>
+  <a href="https://codecov.io/gh/ayagmar/llm-usage-metrics"><img src="https://img.shields.io/codecov/c/github/ayagmar/llm-usage-metrics?style=flat-square" alt="test coverage"></a>
+</p>
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ayagmar/llm-usage-metrics)
-[![npm version](https://img.shields.io/npm/v/llm-usage-metrics.svg?style=flat-square&color=0ea5e9)](https://www.npmjs.com/package/llm-usage-metrics)
-[![npm downloads](https://img.shields.io/npm/dt/llm-usage-metrics.svg?style=flat-square&color=10b981)](https://www.npmjs.com/package/llm-usage-metrics)
-[![CI](https://img.shields.io/github/actions/workflow/status/ayagmar/llm-usage-metrics/ci.yml?style=flat-square&label=CI)](https://github.com/ayagmar/llm-usage-metrics/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/codecov/c/github/ayagmar/llm-usage-metrics?style=flat-square)](https://codecov.io/gh/ayagmar/llm-usage-metrics)
+<p align="center">
+  <a href="https://ayagmar.github.io/llm-usage-metrics/">Documentation</a> ·
+  <a href="https://ayagmar.github.io/llm-usage-metrics/getting-started/">Getting started</a> ·
+  <a href="https://ayagmar.github.io/llm-usage-metrics/cli-reference/">CLI reference</a> ·
+  <a href="./CONTRIBUTING.md">Contributing</a>
+</p>
 
-[📖 Documentation](https://ayagmar.github.io/llm-usage-metrics/) ·
-[⚡ Quick Start](#quick-start) ·
-[📊 Examples](#usage) ·
-[🤝 Contributing](./CONTRIBUTING.md)
+`llm-usage-metrics` reads local session data from 16 AI coding tools and converts it into one normalized usage history. Use it to review tokens and estimated cost, compare periods, find expensive sessions, correlate usage with local Git activity, or export the result.
 
-</div>
+The CLI parses session content on your machine. It discovers standard source locations and includes a bundled pricing snapshot, so the first report can run without configuration or network access.
 
----
+## Quick start
 
-Aggregate token usage and costs from your local coding agent sessions. Supports **pi**, **codex**, **Gemini CLI**, **Droid CLI**, **OpenCode**, **OpenClaw**, **Claude Code**, **GitHub Copilot CLI**, **Goose**, **Amp**, **Qwen CLI**, **Kimi CLI/Kimi Code**, **Cline**, **RooCode**, **KiloCode**, and **Antigravity** with zero configuration required.
-
-## ✨ Features
-
-- **Zero-Config Discovery** — Automatically finds `.pi`, `.codex`, `.gemini`, `.factory`, OpenCode, OpenClaw, Claude, Copilot, Goose, Amp, Qwen, Kimi, Cline, RooCode, KiloCode, and Antigravity session data
-- **LiteLLM Pricing** — Real-time pricing sync with cache and bundled offline fallback support
-- **Flexible Reports** — Daily, weekly, and monthly aggregations
-- **Efficiency Reports** — Correlate cost/tokens with repository commit outcomes
-- **Optimize Reports** — Counterfactual candidate-model pricing against observed token mix
-- **Trends Reports** — Daily cost or token trend views with combined or per-source output
-- **Session Reports** — Group usage by conversation session to find high-cost work
-- **Wrapped Recaps** — Yearly usage recap with a shareable SVG
-- **Doctor Command** — Check source discovery health when reports show no sessions
-- **Multiple Outputs** — Terminal tables, JSON, or Markdown
-- **Smart Filtering** — By source, billing provider, model, and date ranges
-
-## 🚀 Quick Start
+Requires Node.js 24 or newer.
 
 ```bash
-# Install globally
+# Run without installing
+npx --yes llm-usage-metrics@latest daily
+
+# Or install the llm-usage command
 npm install -g llm-usage-metrics
-
-# Or run without installing
-npx llm-usage-metrics@latest daily
-
-# Generate your first report
 llm-usage daily
 ```
 
-<div align="center">
-
-![Terminal output showing token usage and cost breakdown](https://ayagmar.github.io/llm-usage-metrics/screenshot.png)
-
-</div>
-
-## 📋 Supported Sources
-
-| Source          | Pattern                                                                                  | Discovery                            |
-| --------------- | ---------------------------------------------------------------------------------------- | ------------------------------------ |
-| **pi**          | `~/.pi/agent/sessions/**/*.jsonl` (+ `~/.omp/agent/sessions`)                            | Automatic                            |
-| **codex**       | `~/.codex/sessions/**/*.jsonl`                                                           | Automatic                            |
-| **Gemini CLI**  | `~/.gemini/tmp/*/chats/*.json` (or `$GEMINI_CLI_HOME` when set)                          | Automatic                            |
-| **Droid CLI**   | `~/.factory/sessions/**/*.settings.json`                                                 | Automatic                            |
-| **OpenCode**    | `~/.local/share/opencode/opencode*.db`                                                   | Auto or explicit `--opencode-db`     |
-| **OpenClaw**    | `~/.openclaw/agents/**/*.jsonl` (+ legacy `~/.clawdbot`/`~/.moltbot`/`~/.moldbot` homes) | Automatic                            |
-| **Claude Code** | `~/.claude/{projects,transcripts}/**/*.jsonl`                                            | Automatic                            |
-| **Copilot CLI** | `~/.copilot/otel/*.jsonl` (+ `$COPILOT_OTEL_FILE_EXPORTER_PATH` file when set)           | Automatic                            |
-| **Goose**       | `~/.local/share/goose/sessions/sessions.db` (or `$GOOSE_PATH_ROOT/data/sessions`)        | Auto or explicit `--goose-db`        |
-| **Amp**         | `~/.local/share/amp/threads/*.json`                                                      | Auto or explicit `--amp-dir`         |
-| **Qwen CLI**    | `~/.qwen/projects/*/chats/*.jsonl`                                                       | Auto or explicit `--qwen-dir`        |
-| **Kimi**        | `~/.kimi/sessions/**/wire.jsonl` + `~/.kimi-code/sessions/**/wire.jsonl`                 | Auto or explicit `--kimi-dir`        |
-| **Cline**       | VS Code global storage `saoudrizwan.claude-dev/tasks/**/ui_messages.json`                | Auto or explicit `--cline-dir`       |
-| **RooCode**     | VS Code global storage `rooveterinaryinc.roo-cline/tasks/**/ui_messages.json`            | Auto or explicit `--roocode-dir`     |
-| **KiloCode**    | VS Code global storage `kilocode.kilo-code/tasks/**/ui_messages.json`                    | Auto or explicit `--kilocode-dir`    |
-| **Antigravity** | `~/.gemini/antigravity-cli/conversations/*.db` (or `$GEMINI_CLI_HOME`)                   | Auto or explicit `--antigravity-dir` |
-
-SQLite-backed sources (OpenCode, Goose, Antigravity) require Node.js 24+ runtime with built-in `node:sqlite`.
-
-For `droid`, `Input`, `Output`, `Reasoning`, `Cache Read`, and `Cache Write` come directly from session files, and `totalTokens` is billable raw tokens (`Input + Output + Cache Read + Cache Write`, excluding `Reasoning`). Factory dashboard totals may differ because Factory applies standard-token normalization/multipliers.
-
-## 🎯 Usage
-
-### Basic Reports
+If the report is empty, check source discovery:
 
 ```bash
-# Daily report (default terminal table)
-llm-usage daily
-
-# Weekly with timezone
-llm-usage weekly --timezone Europe/Paris
-
-# Monthly date range
-llm-usage monthly --since 2026-01-01 --until 2026-01-31
+llm-usage doctor
 ```
 
-### Compare
+## Reports
+
+| Question                                                  | Command                                |
+| --------------------------------------------------------- | -------------------------------------- |
+| How much did I use by day, week, or month?                | `llm-usage daily`, `weekly`, `monthly` |
+| How did one period change from another?                   | `llm-usage compare`                    |
+| Which conversations or repositories used the most?        | `llm-usage session`                    |
+| How is daily usage moving?                                | `llm-usage trends`                     |
+| How does repo-attributed usage line up with Git activity? | `llm-usage efficiency monthly`         |
+| What would the same token mix cost on another model?      | `llm-usage optimize monthly`           |
+| What did the year add up to?                              | `llm-usage wrapped`                    |
+| Which sources and local stores are healthy?               | `llm-usage doctor`                     |
+| Which departed files can leave the event ledger?          | `llm-usage prune`                      |
+
+Common examples:
 
 ```bash
-# Compare the current local calendar month to the previous month
+# A chosen calendar range
+llm-usage monthly --since 2026-06-01 --until 2026-06-30
+
+# Current local month compared with the previous month
 llm-usage compare
 
-# Compare explicit windows
-llm-usage compare --since 2026-06-01 --until 2026-06-30 --vs-since 2026-05-01 --vs-until 2026-05-31
+# Ten highest-cost conversations
+llm-usage session --top 10
+
+# Usage grouped by repository
+llm-usage session --by-repo
+
+# Last 14 local days as a token series
+llm-usage trends --metric tokens --days 14
+
+# Candidate-model pricing against observed usage
+llm-usage optimize monthly \
+  --provider openai \
+  --candidate-model gpt-4.1 \
+  --candidate-model gpt-5-codex
 ```
 
-`compare` applies the same source, provider, model, pricing, timezone, and `--history` filters to both windows. When `--vs-since` and `--vs-until` are omitted, the baseline is the immediately preceding window.
+## Supported sources
 
-### Output Formats
+| Source                 | Local format  |
+| ---------------------- | ------------- |
+| pi                     | JSONL         |
+| codex                  | JSONL         |
+| Gemini CLI             | JSON          |
+| Droid CLI              | settings JSON |
+| OpenCode               | SQLite        |
+| OpenClaw               | JSONL         |
+| Claude Code            | JSONL         |
+| GitHub Copilot CLI     | OTEL JSONL    |
+| Goose                  | SQLite        |
+| Amp                    | JSON          |
+| Qwen CLI               | JSONL         |
+| Kimi CLI and Kimi Code | wire JSONL    |
+| Cline                  | task JSON     |
+| RooCode                | task JSON     |
+| KiloCode               | task JSON     |
+| Antigravity            | SQLite        |
+
+Each source adapter owns discovery and source-specific token normalization. Reports operate on the same `UsageEvent` shape after parsing. The [source documentation](https://ayagmar.github.io/llm-usage-metrics/sources/) lists default paths, override flags, and adapter-specific semantics.
+
+SQLite-backed sources use the built-in `node:sqlite` module.
+
+## Filters and configuration
 
 ```bash
-# JSON for pipelines
+# Filter by source tool
+llm-usage monthly --source codex,claude
+
+# Filter by normalized billing provider
+llm-usage monthly --provider openai
+
+# Filter by exact model or substring
+llm-usage monthly --model codex
+
+# Create a commented TOML config with editor schema support
+llm-usage config init
+```
+
+`--source` identifies the tool that wrote an event. `--provider` identifies the billing entity behind its model. A Codex session can have `source=codex` and `provider=openai`.
+
+The config precedence order is CLI flags, environment variables, TOML config, then built-in defaults. See [Configuration](https://ayagmar.github.io/llm-usage-metrics/configuration/) for every key and source path override.
+
+## Pricing
+
+The CLI keeps a valid cost supplied by a source. When a source has no cost, it estimates one from LiteLLM pricing.
+
+Pricing loads from a fresh cache, a network refresh, a stale cache, or the bundled snapshot. Use offline mode to skip the network request:
+
+```bash
+llm-usage monthly --pricing-offline
+```
+
+Cost rendering makes incomplete data visible:
+
+- `$12.34` means the full row has resolved cost.
+- `~$12.34` means the known cost is partial.
+- `-` means no contributing event has a resolved cost.
+
+The pricing request never includes session content. See [Pricing](https://ayagmar.github.io/llm-usage-metrics/pricing/) for rate matching, overrides, and error behavior.
+
+## Local event ledger
+
+A SQLite event ledger stores normalized events and parse diagnostics. Unchanged files can skip parsing on later runs. The ledger also supports retained history for files that have left the disk:
+
+```bash
+llm-usage monthly --history
+```
+
+`prune` is a dry run unless you pass `--apply`:
+
+```bash
+llm-usage prune --suppressed
+llm-usage prune --departed-before 2026-01-01 --apply
+```
+
+Deleting the ledger also deletes retained history. Read [Caching](https://ayagmar.github.io/llm-usage-metrics/caching/) before clearing it as a troubleshooting step.
+
+## Output
+
+```bash
 llm-usage daily --json
-
-# Markdown for documentation
 llm-usage daily --markdown
-
-# Detailed per-model breakdown
-llm-usage monthly --per-model-columns
-
-# Write a share SVG image
 llm-usage monthly --share
 ```
 
-Usage tables rank per-period model breakdowns by total tokens so the dominant models appear first in terminal and Markdown output.
+Report data goes to `stdout`. Discovery, pricing, config, and skipped-row diagnostics go to `stderr`, which keeps JSON and Markdown safe to redirect.
 
-### Trends
+Terminal, JSON, and Markdown availability varies by report. Usage, trends, wrapped, efficiency, and optimize can write supported share SVGs. The [output guide](https://ayagmar.github.io/llm-usage-metrics/output-formats/) contains the format matrix and file names.
 
-```bash
-# Last 30 local days of cost by default
-llm-usage trends
+## Performance
 
-# Token trends for the last 7 days
-llm-usage trends --metric tokens --days 7
+The repository publishes absolute cold and warm runtimes on real local corpora. The comparison includes the runs where `ccusage` is faster and the warm Claude run where the event ledger is faster. It also records the machine, commands, cache state, dataset size, and five-run distribution.
 
-# Per-source trends in JSON
-llm-usage trends --by-source --json
+Read and reproduce the [benchmark](https://ayagmar.github.io/llm-usage-metrics/benchmarks/) before applying its results to another workload.
 
-# Write a combined trends share SVG
-llm-usage trends --share --days 7
-```
-
-Trends is terminal-first and supports `--json` and `--share`. It does not support `--markdown`.
-`--share` renders the combined trends view; run without `--by-source`.
-
-### Session Reports
+## Development
 
 ```bash
-# Group usage by conversation session (top 20 by cost by default)
-llm-usage session
-
-# Show every session
-llm-usage session --top 0
-
-# Look up sessions whose id contains a value (case-insensitive substring)
-llm-usage session --id 486c
-
-# Group usage by repository root instead of by session
-llm-usage session --by-repo --top 5
-
-# Keep only the highest-cost sessions in JSON output
-llm-usage session --top 5 --json
-
-# Markdown table for notes or docs
-llm-usage session --markdown
-```
-
-Session reports group events by source and session id, then sort sessions by total cost descending.
-By default only the top 20 rows are shown (in terminal, Markdown, and JSON output alike) and a stderr note reports how many rows were hidden; use `--top 0` to print everything.
-`--id` filters sessions by case-insensitive substring match on the full session id (repeatable or comma-separated), renders matching ids untruncated, and disables the default limit (an explicit `--top` still applies). It cannot be combined with `--by-repo`.
-`--by-repo` prints one row per repository root with distinct session counts and the contributing sources; events without a repository fall into a `(no repo)` bucket. The table shows the directory basename while JSON keeps the full path.
-The session table shows the repo, last activity, total tokens, cost, and up to two models per session; JSON output keeps all fields (event counts, cache buckets, the full model list, and full repository paths).
-Date, source, provider, and model filters apply to events before grouping, so a session spanning a boundary shows only the matching in-range usage.
-Session reports do not include a TOTAL row because the rows represent conversations rather than calendar periods.
-
-### Wrapped Recap
-
-```bash
-# Current-year recap in the report timezone
-llm-usage wrapped
-
-# Fixed-year recap as JSON
-llm-usage wrapped --year 2026 --json
-
-# Scope the recap to a billing provider or model
-llm-usage wrapped --year 2026 --provider anthropic
-
-# Write the share SVG
-llm-usage wrapped --year 2026 --share
-```
-
-```text
-┌──────────────┐
-│ Wrapped 2026 │
-└──────────────┘
-2026-01-01 to 2026-12-31 (UTC)
-
-Tokens          48,200,000
-Cost            $214.90
-Active days     143
-Longest streak  21 days
-Events          8,640
-Sessions        512
-
-Monthly activity
-Jan ▂  Feb █  Mar █  Apr ▄  May ▂  Jun ▁  Jul ▁  Aug ·  Sep ▁  Oct ▂  Nov ▄  Dec █
-
-Top models
-╭───┬───────────────────┬────────────┬────────╮
-│ # │ Model             │     Tokens │   Cost │
-├───┼───────────────────┼────────────┼────────┤
-│ 1 │ gpt-5.1           │ 21,400,000 │ $96.20 │
-├───┼───────────────────┼────────────┼────────┤
-│ 2 │ claude-sonnet-4-6 │ 14,800,000 │ $72.50 │
-├───┼───────────────────┼────────────┼────────┤
-│ 3 │ gpt-5.1-codex     │  8,900,000 │ $31.70 │
-├───┼───────────────────┼────────────┼────────┤
-│ 4 │ gemini-3-pro      │  2,100,000 │  $9.80 │
-├───┼───────────────────┼────────────┼────────┤
-│ 5 │ claude-opus-4-8   │  1,000,000 │  $4.70 │
-╰───┴───────────────────┴────────────┴────────╯
-
-Top sources
-╭───┬──────────┬────────────┬─────────╮
-│ # │ Source   │     Tokens │    Cost │
-├───┼──────────┼────────────┼─────────┤
-│ 1 │ codex    │ 26,300,000 │ $121.40 │
-├───┼──────────┼────────────┼─────────┤
-│ 2 │ claude   │ 15,800,000 │  $77.20 │
-├───┼──────────┼────────────┼─────────┤
-│ 3 │ pi       │  4,000,000 │  $12.50 │
-├───┼──────────┼────────────┼─────────┤
-│ 4 │ gemini   │  1,600,000 │   $3.10 │
-├───┼──────────┼────────────┼─────────┤
-│ 5 │ opencode │    500,000 │   $0.70 │
-╰───┴──────────┴────────────┴─────────╯
-```
-
-Wrapped computes yearly totals, active days, longest streak, the top five models, the top five sources, and a 12-month intensity strip.
-`--provider` and `--model` scope the recap the same way they do on the other reports; `--year` owns the date range, so `--since`/`--until` are unavailable.
-The terminal report uses the shared boxed header, tables, and color policy — set `NO_COLOR` for plain text.
-The share output is an offline SVG named `llm-usage-wrapped-<year>.svg` (its top lists show three rows); PNG rendering and embedded logo/font assets are intentionally out of scope.
-
-### Doctor
-
-```bash
-# Check source discovery health without parsing sessions
-llm-usage doctor
-
-# JSON for support/debugging pipelines
-llm-usage doctor --json
-```
-
-Doctor prints one line per source and exits 0 even when a source is unhealthy.
-
-```text
-pi        ok     12 file(s)
-opencode  error  OpenCode database is missing or unreadable: /path/to/opencode.db
-
-15/16 sources healthy
-```
-
-### Efficiency Reports
-
-```bash
-# Daily efficiency in current repository
-llm-usage efficiency daily
-
-# Weekly efficiency for a specific repository path
-llm-usage efficiency weekly --repo-dir /path/to/repo
-
-# Include merge commits and export JSON
-llm-usage efficiency monthly --include-merge-commits --json
-
-# Write a monthly share SVG
-llm-usage efficiency monthly --share
-```
-
-Efficiency reports are repo-attributed: usage events are mapped to a Git repository root using source metadata (`cwd`/path info), and only events attributed to the selected repo are included in efficiency totals.
-
-#### Reading efficiency output
-
-- `Commits`, `+Lines`, `-Lines`, `ΔLines` come from local Git shortstat outcomes (for your configured Git author).
-- `Input`, `Output`, `Reasoning`, `Cache Read`, `Cache Write`, `Total`, and `Cost` come from repo-attributed usage events.
-- `Tokens/Commit` uses `(Input + Output + Reasoning) / Commits` and excludes cache read/write tokens.
-- `$/Commit` uses `Cost / Commits`.
-- `$/1k Lines` uses `Cost / (ΔLines / 1000)`.
-- `Commits/$` uses `Commits / Cost` (shown only when `Cost > 0`).
-
-Efficiency period rows are emitted only when both Git outcomes and repo-attributed usage signal exist for that period.
-When a denominator is zero, derived values in emitted rows render as `-`.  
-When pricing is incomplete, terminal/markdown output prefixes affected USD metrics with `~`.
-
-For source-by-source comparisons, run the same report per source:
-
-```bash
-llm-usage efficiency monthly --repo-dir /path/to/repo --source pi
-llm-usage efficiency monthly --repo-dir /path/to/repo --source codex
-llm-usage efficiency monthly --repo-dir /path/to/repo --source gemini
-llm-usage efficiency monthly --repo-dir /path/to/repo --source droid
-llm-usage efficiency monthly --repo-dir /path/to/repo --source opencode
-llm-usage efficiency monthly --repo-dir /path/to/repo --source openclaw
-llm-usage efficiency monthly --repo-dir /path/to/repo --source claude
-llm-usage efficiency monthly --repo-dir /path/to/repo --source copilot
-llm-usage efficiency monthly --repo-dir /path/to/repo --source goose
-llm-usage efficiency monthly --repo-dir /path/to/repo --source amp
-llm-usage efficiency monthly --repo-dir /path/to/repo --source qwen
-llm-usage efficiency monthly --repo-dir /path/to/repo --source kimi
-llm-usage efficiency monthly --repo-dir /path/to/repo --source cline
-llm-usage efficiency monthly --repo-dir /path/to/repo --source roocode
-llm-usage efficiency monthly --repo-dir /path/to/repo --source kilocode
-llm-usage efficiency monthly --repo-dir /path/to/repo --source antigravity
-```
-
-Note: usage filters (`--source`, `--provider`, `--model`, `--pi-dir`, `--codex-dir`, `--copilot-dir`, `--gemini-dir`, `--droid-dir`, `--claude-dir`, `--openclaw-dir`, `--amp-dir`, `--qwen-dir`, `--kimi-dir`, `--cline-dir`, `--roocode-dir`, `--kilocode-dir`, `--antigravity-dir`, `--opencode-db`, `--goose-db`, `--source-dir`) also constrain commit attribution: only commit days with matching repo-attributed usage events are counted.
-
-### Optimize Reports
-
-```bash
-# Counterfactual pricing across candidate models
-llm-usage optimize monthly --provider openai --candidate-model gpt-4.1 --candidate-model gpt-5-codex
-
-# Keep only the cheapest candidate in JSON output
-llm-usage optimize weekly --provider openai --candidate-model gpt-4.1,gpt-5-codex --top 1 --json
-
-# Write a monthly share SVG
-llm-usage optimize monthly --provider openai --candidate-model gpt-4.1 --candidate-model gpt-5-codex --share
-```
-
-`--provider` filters by billing entity. Provider aliases are normalized to billing roots (for example, `openai-codex` is treated as `openai`).
-
-### Filtering
-
-```bash
-# By source
-llm-usage monthly --source pi,codex,gemini,droid,openclaw,claude,copilot,goose,amp,qwen,kimi,cline,roocode,kilocode,antigravity
-
-# By provider
-llm-usage monthly --provider openai
-
-# By model
-llm-usage monthly --model claude
-
-# Combined filters
-llm-usage monthly --source opencode --provider openai --model gpt-4.1
-```
-
-Use `--source` to scope where events came from (`pi`, `codex`, `gemini`, `droid`, `opencode`, `openclaw`, `claude`, `copilot`, `goose`, `amp`, `qwen`, `kimi`, `cline`, `roocode`, `kilocode`, `antigravity`), and `--provider` to scope the billing entity behind those events.
-
-### Custom Paths
-
-```bash
-# Custom directories
-llm-usage daily --source-dir pi=/path/to/pi --source-dir codex=/path/to/codex --source-dir gemini=/path/to/.gemini --source-dir droid=/path/to/.factory/sessions --source-dir openclaw=/path/to/.openclaw/agents --source-dir claude=/path/to/.claude/projects --source-dir copilot=/path/to/.copilot/otel --source-dir amp=/path/to/amp/threads --source-dir qwen=/path/to/.qwen/projects --source-dir kimi=/path/to/kimi/sessions --source-dir cline=/path/to/cline/tasks --source-dir roocode=/path/to/roocode/tasks --source-dir kilocode=/path/to/kilocode/tasks --source-dir antigravity=/path/to/antigravity/conversations
-
-# Explicit Gemini/Droid/Claude/OpenClaw/Copilot/Amp/Qwen/Kimi/Cline/RooCode/KiloCode/Antigravity/OpenCode/Goose paths
-llm-usage daily --gemini-dir /path/to/.gemini
-llm-usage daily --droid-dir /path/to/.factory/sessions
-llm-usage daily --claude-dir /path/to/.claude/projects
-llm-usage daily --openclaw-dir /path/to/.openclaw/agents
-llm-usage daily --copilot-dir /path/to/.copilot/otel
-llm-usage daily --amp-dir /path/to/amp/threads
-llm-usage daily --qwen-dir /path/to/.qwen/projects
-llm-usage daily --kimi-dir /path/to/kimi/sessions
-llm-usage daily --cline-dir /path/to/cline/tasks
-llm-usage daily --roocode-dir /path/to/roocode/tasks
-llm-usage daily --kilocode-dir /path/to/kilocode/tasks
-llm-usage daily --antigravity-dir /path/to/antigravity/conversations
-llm-usage daily --opencode-db /path/to/opencode.db
-llm-usage daily --goose-db /path/to/goose/sessions.db
-```
-
-### Offline Mode
-
-Pricing uses LiteLLM rates. Online runs refresh the local pricing cache when
-needed; offline runs use a fresh or stale cache when present and fall back to
-the bundled LiteLLM snapshot when no cache exists. When the bundled snapshot is
-used, `stderr` shows its snapshot date and suggests running online to refresh.
-
-```bash
-# Avoid network pricing fetches
-llm-usage monthly --pricing-offline
-
-# Continue even if pricing fetch fails
-llm-usage monthly --ignore-pricing-failures
-
-# Override per-model pricing from a local JSON file
-llm-usage monthly --pricing-overrides ./pricing-overrides.json
-```
-
-Custom `--pricing-url` values use their matching cache or network source; they
-do not silently fall back to the bundled default LiteLLM snapshot.
-
-## 🧪 Production Benchmarks
-
-Absolute runtimes measured on 2026-07-09 on real local data, with `ccusage` (a native Rust binary) as context; full methodology lives on the [Benchmarks docs page](https://ayagmar.github.io/llm-usage-metrics/benchmarks/).
-
-codex — `daily` (5 runs each):
-
-| Tool                                               | Cache | Median (s) | Mean (s) |
-| -------------------------------------------------- | ----- | ---------: | -------: |
-| `ccusage codex daily`                              | cold  |      0.516 |    0.515 |
-| `ccusage codex daily --offline`                    | warm  |      0.292 |    0.292 |
-| `llm-usage daily --source codex`                   | cold  |      1.655 |    1.670 |
-| `llm-usage daily --source codex --pricing-offline` | warm  |      0.996 |    1.005 |
-
-claude — `daily` (5 runs each):
-
-| Tool                                                | Cache | Median (s) | Mean (s) |
-| --------------------------------------------------- | ----- | ---------: | -------: |
-| `ccusage claude daily`                              | cold  |      0.335 |    0.354 |
-| `ccusage claude daily --offline`                    | warm  |      0.478 |    0.474 |
-| `llm-usage daily --source claude`                   | cold  |      0.883 |    0.896 |
-| `llm-usage daily --source claude --pricing-offline` | warm  |      0.256 |    0.255 |
-
-Cold runs favor ccusage (native Rust); warm claude favors llm-usage (~1.9x) thanks to the SQLite event store; warm codex is ~1.0 s.
-
-Reproduce locally:
-
-```bash
-pnpm run build
-npx -y ccusage@latest --version
-CCUSAGE_BIN=$(find ~/.npm/_npx -name ccusage -path '*/.bin/*' | head -1)
-node scripts/perf-production-benchmark.mjs --runs 5 --scenario codex --ccusage-bin "$CCUSAGE_BIN"
-node scripts/perf-production-benchmark.mjs --runs 5 --scenario claude --ccusage-bin "$CCUSAGE_BIN"
-```
-
-## ⚙️ Configuration
-
-`llm-usage-metrics` reads persistent defaults from a TOML config file:
-
-```text
-<config-root>/llm-usage-metrics/config.toml
-```
-
-Run `llm-usage config init` to write a commented template. Set
-`LLM_USAGE_CONFIG_PATH=/path/to/config.toml` to use a different file.
-Missing config files are ignored, malformed TOML fails with an actionable
-error, and unknown keys are reported on `stderr`.
-
-Example:
-
-```toml
-#:schema https://ayagmar.github.io/llm-usage-metrics/config-schema.json
-timezone = "Africa/Casablanca"
-logLevel = "info"
-sources = ["codex", "claude"]
-parseMaxParallel = 8
-parseWorkers = "auto"
-parseWorkerMinBytes = 268435456
-
-[sourceDirs]
-codex = "/path/to/.codex/sessions"
-claude = "/path/to/.claude/projects"
-
-[pricing]
-offline = true
-
-[eventStore]
-enabled = true
-path = "/path/to/events.db"
-```
-
-Precedence is `CLI flags` → `environment variables` → `config file` →
-`built-in defaults`. Applied config values are shown on `stderr` as an
-`Active config:` block. Set `logLevel = "warn"` to suppress informational
-stderr by default, or pass `--quiet` to do the same for a single report
-command.
-
-### Environment Overrides
-
-Environment variables remain available for CI, scripts, and temporary runtime
-overrides.
-
-| Variable                             | Config key                    |
-| ------------------------------------ | ----------------------------- |
-| `LLM_USAGE_CONFIG_PATH`              | Selects the config file       |
-| `LLM_USAGE_SKIP_UPDATE_CHECK`        | `update.skipCheck`            |
-| `LLM_USAGE_PARSE_WORKERS`            | `parseWorkers`                |
-| `LLM_USAGE_PARSE_WORKER_MIN_BYTES`   | `parseWorkerMinBytes`         |
-| `LLM_USAGE_EVENT_STORE`              | `eventStore.enabled`          |
-| `LLM_USAGE_EVENT_STORE_PATH`         | `eventStore.path`             |
-| `LLM_USAGE_UPDATE_CACHE_SCOPE`       | Update cache mode override    |
-| `LLM_USAGE_UPDATE_CACHE_SESSION_KEY` | Update cache session key      |
-| `LLM_USAGE_PROFILE_RUNTIME`          | Runtime profiling diagnostics |
-
-### SQLite Event Store
-
-`llm-usage` stores parsed file events in
-`<platform-cache-root>/llm-usage-metrics/events.db` so unchanged source files do
-not need to be reparsed on every run. The store also retains departed-file rows
-for `--history` reports. On Linux with no `XDG_CACHE_HOME`, that is usually
-`~/.cache/llm-usage-metrics/events.db`.
-
-Use `--history` on report commands to include usage from files that no longer
-exist on disk. History follows the same source, provider, model, date, pricing,
-and aggregation behavior as live-file reports. If a file was moved, renamed, or
-copied, the store suppresses the departed copy by content hash so it is not
-double counted. History quality depends on how long the event store has been
-running on your machine.
-
-Use `llm-usage prune` for explicit event-store maintenance. Prune is a dry-run
-by default: it prints the departed-file candidates and deletes nothing until
-`--apply` is present.
-
-- `llm-usage prune --suppressed` selects departed files already suppressed by
-  `--history`; applying it does not change report output.
-- `llm-usage prune --departed-before YYYY-MM-DD` selects departed files whose
-  newest event timestamp is strictly older than that UTC date. Applying it
-  permanently deletes retained history for those files.
-- `llm-usage prune ... --apply` deletes the selected rows, runs SQLite
-  `VACUUM`, and reports reclaimed database/WAL bytes.
-
-- Set `LLM_USAGE_EVENT_STORE=0` to disable the store for cold-run benchmarking
-  or debugging. `--history` requires the store to be enabled.
-- Set `LLM_USAGE_EVENT_STORE_PATH=/path/to/events.db` to use an isolated store.
-- Back up `events.db` if retained history matters. Deleting it deletes local
-  history and starts a new ledger from the next run.
-- The first run after upgrading the store schema migrates `events.db` in place
-  and may take a few seconds on large stores.
-- Older JSON cache shards from pre-store versions are no longer read and can be
-  deleted manually.
-
-See the full config and environment override reference in the [documentation](https://ayagmar.github.io/llm-usage-metrics/configuration/).
-
-### Update Checks
-
-The CLI performs lightweight update checks with smart defaults:
-
-- 1-hour cache TTL
-- Fresh cached update results are used immediately without any network call
-- Stale or missing cache triggers a bounded fetch (default 1s timeout) so the update hint stays consistent across commands, instead of silently skipping the run that refreshes the cache
-- Runs concurrently with the report, so it never delays your output
-- When an update is available, prints a one-line hint to stderr after the report with the `npm install -g` command — it never prompts, installs, or restarts
-- Skipped for `--help`, `--version`, `npx`, and direct source/development runs
-
-Disable with:
-
-```bash
-LLM_USAGE_SKIP_UPDATE_CHECK=1 llm-usage daily
-```
-
-## 🛠️ Development
-
-```bash
-# Install dependencies
 pnpm install
-
-# Run quality checks
 pnpm run lint
 pnpm run typecheck
 pnpm run test
 pnpm run format:check
-
-# Build
 pnpm run build
-
-# Run locally
-pnpm cli daily
 ```
 
-## 📚 Documentation
+Site commands:
 
-- **[Getting Started](https://ayagmar.github.io/llm-usage-metrics/getting-started/)** — Installation and first steps
-- **[CLI Reference](https://ayagmar.github.io/llm-usage-metrics/cli-reference/)** — Complete command reference
-- **[Efficiency](https://ayagmar.github.io/llm-usage-metrics/efficiency/)** — Efficiency report semantics and interpretation
-- **[Optimize](https://ayagmar.github.io/llm-usage-metrics/optimize/)** — Counterfactual candidate-model pricing semantics
-- **[Data Sources](https://ayagmar.github.io/llm-usage-metrics/sources/)** — Source configuration
-- **[Configuration](https://ayagmar.github.io/llm-usage-metrics/configuration/)** — Config file and environment overrides
-- **[Security](https://ayagmar.github.io/llm-usage-metrics/security/)** — Current security controls, dependency hygiene, and contributor steps
-- **[Benchmarks](https://ayagmar.github.io/llm-usage-metrics/benchmarks/)** — Production benchmark methodology and results
-- **[Architecture](https://ayagmar.github.io/llm-usage-metrics/architecture/)** — Technical overview
+```bash
+pnpm run site:check
+pnpm run site:build
+pnpm run site:dev
+```
 
-## 🔐 Security
+See [CONTRIBUTING.md](./CONTRIBUTING.md) and [docs/development.md](./docs/development.md) for the contributor workflow.
 
-Current repo protections include exact direct dependency pins, frozen-lockfile installs in CI, committed lockfile integrity hashes, SHA-pinned GitHub Actions, Dependabot for dependency and workflow updates, dedicated security workflows (`pnpm audit`, Dependency Review, and CodeQL), and OIDC-based npm trusted publishing.
-See the full security guide: **[Security](https://ayagmar.github.io/llm-usage-metrics/security/)**.
+## License
 
-## 🤝 Contributing
-
-Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
-
-The codebase is structured to add more sources through the `SourceAdapter` pattern.
-
-## 📄 License
-
-MIT © [Abdeslam Yagmar](https://github.com/ayagmar)
+[MIT](./LICENSE)

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -7,13 +7,13 @@ export default defineConfig({
 
   integrations: [
     starlight({
-      title: 'llm-usage-metrics',
+      title: 'LLM Usage Metrics',
       description:
-        'CLI for aggregating local LLM usage and cost metrics across 16 local coding agents, with pricing, trends, efficiency reports, and yearly recaps',
+        'Local-first usage reports for 16 AI coding tools, with pricing, session analysis, Git attribution, comparisons, and exports',
       favicon: '/favicon.svg',
       logo: {
         src: './src/assets/logo.svg',
-        replacesTitle: true,
+        replacesTitle: false,
       },
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/ayagmar/llm-usage-metrics' },
@@ -41,39 +41,45 @@ export default defineConfig({
             href: 'https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap',
           },
         },
+        {
+          tag: 'meta',
+          attrs: {
+            name: 'theme-color',
+            content: '#11130f',
+          },
+        },
       ],
       sidebar: [
         {
-          label: 'Getting Started',
-          link: '/getting-started',
+          label: 'Start here',
+          items: [
+            { label: 'Getting started', link: '/getting-started/' },
+            { label: 'Data sources', link: '/sources/' },
+            { label: 'Configuration', link: '/configuration/' },
+          ],
         },
         {
-          label: 'CLI Reference',
-          link: '/cli-reference',
+          label: 'Reports',
+          items: [
+            { label: 'CLI reference', link: '/cli-reference/' },
+            { label: 'Compare periods', link: '/compare/' },
+            { label: 'Session usage', link: '/session/' },
+            { label: 'Trends', link: '/trends/' },
+            { label: 'Efficiency', link: '/efficiency/' },
+            { label: 'Optimize', link: '/optimize/' },
+            { label: 'Wrapped recap', link: '/wrapped/' },
+            { label: 'Output formats', link: '/output-formats/' },
+          ],
         },
         {
-          label: 'Efficiency',
-          link: '/efficiency',
-        },
-        {
-          label: 'Optimize',
-          link: '/optimize',
-        },
-        {
-          label: 'Trends',
-          link: '/trends',
-        },
-        {
-          label: 'Session',
-          link: '/session',
-        },
-        {
-          label: 'Wrapped',
-          link: '/wrapped',
-        },
-        {
-          label: 'Doctor',
-          link: '/doctor',
+          label: 'Operate',
+          items: [
+            { label: 'Pricing', link: '/pricing/' },
+            { label: 'Caching and history', link: '/caching/' },
+            { label: 'Doctor', link: '/doctor/' },
+            { label: 'Troubleshooting', link: '/troubleshooting/' },
+            { label: 'Security', link: '/security/' },
+          ],
         },
         {
           label: 'Data Sources',
@@ -98,32 +104,8 @@ export default defineConfig({
           ],
         },
         {
-          label: 'Configuration',
-          link: '/configuration',
-        },
-        {
-          label: 'Security',
-          link: '/security',
-        },
-        {
-          label: 'Caching',
-          link: '/caching',
-        },
-        {
-          label: 'Output Formats',
-          link: '/output-formats',
-        },
-        {
-          label: 'Benchmarks',
-          link: '/benchmarks',
-        },
-        {
-          label: 'Pricing',
-          link: '/pricing',
-        },
-        {
-          label: 'Troubleshooting',
-          link: '/troubleshooting',
+          label: 'Engineering',
+          items: [{ label: 'Benchmarks', link: '/benchmarks/' }],
         },
         {
           label: 'Architecture',

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -4,6 +4,7 @@ import starlight from '@astrojs/starlight';
 export default defineConfig({
   site: 'https://ayagmar.github.io',
   base: '/llm-usage-metrics',
+  prefetch: false,
 
   integrations: [
     starlight({

--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="8" fill="#10b981"/>
-  <path d="M8 12h16M8 16h12M8 20h8" stroke="#09090b" stroke-width="2" stroke-linecap="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect x="1" y="1" width="30" height="30" rx="8" fill="#df7b52"/>
+  <path d="M8 10.5 12.5 16 8 21.5M16 21.5h8M17 10.5h7" stroke="#24130d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/site/src/assets/logo.svg
+++ b/site/src/assets/logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none">
-  <rect width="32" height="32" rx="8" fill="#10b981"/>
-  <path d="M8 12h16M8 16h12M8 20h8" stroke="#09090b" stroke-width="2" stroke-linecap="round"/>
+  <rect x="1" y="1" width="30" height="30" rx="8" fill="#df7b52"/>
+  <path d="M8 10.5 12.5 16 8 21.5M16 21.5h8M17 10.5h7" stroke="#24130d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/site/src/content/docs/architecture/config-and-logging.mdx
+++ b/site/src/content/docs/architecture/config-and-logging.mdx
@@ -3,7 +3,7 @@ title: Config & Logging
 description: How the TOML config resolves against flags and env vars, and how stderr logging is leveled.
 ---
 
-Configuration answers "what settings apply to this run"; logging answers "what the run tells you about itself". Both are designed around one guarantee: the rest of the code only ever sees resolved values, and everything the tool says about itself goes to `stderr`. [Configuration](/configuration/) documents every key; this page documents the machinery.
+Configuration answers "what settings apply to this run"; logging answers "what the run tells you about itself". Both are designed around one guarantee: the rest of the code only ever sees resolved values, and everything the tool says about itself goes to `stderr`. [Configuration](/llm-usage-metrics/configuration/) documents every key; this page documents the machinery.
 
 ## Layers and precedence
 
@@ -40,7 +40,7 @@ Reports print what configuration actually applied, on `stderr`:
 
 The first line is a `#:schema https://ayagmar.github.io/llm-usage-metrics/config-schema.json` directive, which TOML editors (e.g. Taplo) use for completion and validation. The schema is hand-maintained at `schema/config.schema.json`, and unit tests keep it honest: one test asserts the schema's key paths equal the loader's known-key set, and another asserts the published copy at `site/public/config-schema.json` is byte-identical to it.
 
-Adding a config key therefore touches: the known-key set in `user-config.ts`, both schema copies, the `config init` template, and the key tables in [Configuration](/configuration/) — the tests fail if the schema half of that list is forgotten.
+Adding a config key therefore touches: the known-key set in `user-config.ts`, both schema copies, the `config init` template, and the key tables in [Configuration](/llm-usage-metrics/configuration/) — the tests fail if the schema half of that list is forgotten.
 
 ## Logging levels
 
@@ -53,6 +53,6 @@ Adding a config key therefore touches: the known-key set in `user-config.ts`, bo
 
 ## Related pages
 
-- [Configuration](/configuration/) — the key tables, source path overrides, and env vars.
-- [CLI Reference](/cli-reference/) — the `--quiet` flag and per-command options.
-- [Architecture overview](/architecture/) — where config and logging sit in the runtime.
+- [Configuration](/llm-usage-metrics/configuration/) — the key tables, source path overrides, and env vars.
+- [CLI Reference](/llm-usage-metrics/cli-reference/) — the `--quiet` flag and per-command options.
+- [Architecture overview](/llm-usage-metrics/architecture/) — where config and logging sit in the runtime.

--- a/site/src/content/docs/architecture/event-store.mdx
+++ b/site/src/content/docs/architecture/event-store.mdx
@@ -51,4 +51,4 @@ Prune shares its classification logic (`classifyDepartedFiles`) with the history
 
 - The store runs in WAL journal mode, so `events.db-wal` and `events.db-shm` appear alongside `events.db`; opens use a 2-second busy timeout. To back up the ledger, copy all three files while no report is running.
 - `LLM_USAGE_EVENT_STORE=0` and `LLM_USAGE_EVENT_STORE_PATH` are the per-run env overrides; the persistent equivalents are the `eventStore.enabled` and `eventStore.path` config keys.
-- [Caching](/caching/) covers the user-facing tuning view of the store; [Configuration](/configuration/) documents the config keys.
+- [Caching](/llm-usage-metrics/caching/) covers the user-facing tuning view of the store; [Configuration](/llm-usage-metrics/configuration/) documents the config keys.

--- a/site/src/content/docs/architecture/index.mdx
+++ b/site/src/content/docs/architecture/index.mdx
@@ -102,7 +102,7 @@ That keeps command/docs drift low without duplicating option descriptions outsid
 
 ## Deep dives
 
-- [Event Store](/architecture/event-store/) — the SQLite usage-event ledger: ingest, fingerprints, history, and prune.
-- [Parse Pipeline](/architecture/parse-pipeline/) — how source files are discovered, filtered, parsed, and parallelized.
-- [Pricing Pipeline](/architecture/pricing-pipeline/) — how LiteLLM pricing is fetched, cached, matched to model names, and turned into costs.
-- [Config & Logging](/architecture/config-and-logging/) — how the TOML config resolves against flags and env vars, and how stderr logging is leveled.
+- [Event Store](/llm-usage-metrics/architecture/event-store/) — the SQLite usage-event ledger: ingest, fingerprints, history, and prune.
+- [Parse Pipeline](/llm-usage-metrics/architecture/parse-pipeline/) — how source files are discovered, filtered, parsed, and parallelized.
+- [Pricing Pipeline](/llm-usage-metrics/architecture/pricing-pipeline/) — how LiteLLM pricing is fetched, cached, matched to model names, and turned into costs.
+- [Config & Logging](/llm-usage-metrics/architecture/config-and-logging/) — how the TOML config resolves against flags and env vars, and how stderr logging is leveled.

--- a/site/src/content/docs/architecture/parse-pipeline.mdx
+++ b/site/src/content/docs/architecture/parse-pipeline.mdx
@@ -6,7 +6,7 @@ description: How source files are discovered, filtered, parsed, and parallelized
 The parse pipeline turns on-disk session files into normalized usage events. It is where the tool's performance work lives, and every mechanism on this page exists to keep a multi-GiB corpus parseable in seconds. A report run flows through it in order:
 
 1. Each selected adapter discovers its files.
-2. Discovered files split into event-store **hits** (served from the ledger) and **misses** — see [Event Store](/architecture/event-store/).
+2. Discovered files split into event-store **hits** (served from the ledger) and **misses** — see [Event Store](/llm-usage-metrics/architecture/event-store/).
 3. Misses are parsed under a bounded parallelism budget, on worker threads when a large enough codex miss set justifies them.
 4. Parsed lines normalize into usage events (`createUsageEvent`, `src/domain/`).
 5. Freshly parsed files are ingested back into the ledger; events continue to filtering, pricing, and aggregation.
@@ -24,7 +24,7 @@ Sources with multiple home directories (claude, pi, openclaw, kimi, the cline fa
 - `shouldParseLineBytes` runs on the raw line bytes, **before** UTF-8 decoding. The codex adapter accepts `session_meta` and `turn_context` lines and takes `event_msg` lines only when `token_count` bytes appear; the claude adapter requires both `"assistant"` and `"usage"` byte sequences.
 - `shouldParseLine` runs on the decoded string, before `JSON.parse`. The pi, droid, openclaw, copilot, qwen, and kimi adapters filter here.
 
-In a 1.8 GiB codex corpus, most lines carry no usage data. Rejecting them before `JSON.parse` — and for the byte predicates, before even decoding — is the single biggest cold-run win; the [Benchmarks](/benchmarks/) page shows the measured effect.
+In a 1.8 GiB codex corpus, most lines carry no usage data. Rejecting them before `JSON.parse` — and for the byte predicates, before even decoding — is the single biggest cold-run win; the [Benchmarks](/llm-usage-metrics/benchmarks/) page shows the measured effect.
 
 ## Parallelism
 
@@ -47,6 +47,6 @@ Adapters count skipped rows with per-reason counters (`src/sources/parse-diagnos
 
 ## Related pages
 
-- [Event Store](/architecture/event-store/) — the hit/miss split, fingerprints, and ingest.
-- [Configuration](/configuration/) — the `parseMaxParallel`, `parseWorkers`, and `parseWorkerMinBytes` keys.
-- [Benchmarks](/benchmarks/) — the measured effect of this pipeline on real data.
+- [Event Store](/llm-usage-metrics/architecture/event-store/) — the hit/miss split, fingerprints, and ingest.
+- [Configuration](/llm-usage-metrics/configuration/) — the `parseMaxParallel`, `parseWorkers`, and `parseWorkerMinBytes` keys.
+- [Benchmarks](/llm-usage-metrics/benchmarks/) — the measured effect of this pipeline on real data.

--- a/site/src/content/docs/architecture/pricing-pipeline.mdx
+++ b/site/src/content/docs/architecture/pricing-pipeline.mdx
@@ -3,7 +3,7 @@ title: Pricing Pipeline
 description: How LiteLLM pricing is fetched, cached, matched to local model names, and turned into costs.
 ---
 
-Pricing is the tool's second pipeline: rates come in (LiteLLM JSON or a local overrides file), locally observed model names resolve to pricing keys, and each event gets a cost. This page documents the design; [Pricing](/pricing/) covers the user-facing knobs, cost modes, and row rendering.
+Pricing is the tool's second pipeline: rates come in (LiteLLM JSON or a local overrides file), locally observed model names resolve to pricing keys, and each event gets a cost. This page documents the design; [Pricing](/llm-usage-metrics/pricing/) covers the user-facing knobs, cost modes, and row rendering.
 
 ## Loading rates
 
@@ -39,15 +39,15 @@ A name that survives no stage stays unresolved — its events keep their token c
 
 - Events are `explicit` (the source supplied a cost, which is kept) or `estimated` (computed from rates). One exception: an explicit `costUsd: 0` on a priceable event with a model is treated as suspect and repriced when resolvable pricing exists; if it cannot be repriced, the explicit zero stays.
 - Estimated cost sums four per-1M-token buckets: input, output, cache read, and cache write. Reasoning tokens bill according to the model's `reasoningBilling`: `included-in-output` (the default — reasoning adds nothing on top) or `separate` (a fifth bucket with its own rate).
-- Estimation refuses to guess: if any bucket the event actually used has no defined rate, no cost is computed and the event stays cost-less — surfaced downstream as partial (`~$`) or unresolved (`-`) figures, whose rendering semantics live on [Pricing](/pricing/).
+- Estimation refuses to guess: if any bucket the event actually used has no defined rate, no cost is computed and the event stays cost-less — surfaced downstream as partial (`~$`) or unresolved (`-`) figures, whose rendering semantics live on [Pricing](/llm-usage-metrics/pricing/).
 - Pricing lookups are memoized per resolved model for the duration of a run.
 
 ## Overrides
 
-`--pricing-overrides <file>` (`src/pricing/pricing-override-source.ts`) layers a local JSON per-model rate file over the LiteLLM source. Overrides match on the raw lowercased model name — when a model has an override, alias resolution is skipped entirely so the override wins unambiguously; all other models defer to the LiteLLM source. Entries missing either required rate (`inputPer1MUsd`, `outputPer1MUsd`) are ignored. The file shape is documented on [Pricing](/pricing/).
+`--pricing-overrides <file>` (`src/pricing/pricing-override-source.ts`) layers a local JSON per-model rate file over the LiteLLM source. Overrides match on the raw lowercased model name — when a model has an override, alias resolution is skipped entirely so the override wins unambiguously; all other models defer to the LiteLLM source. Entries missing either required rate (`inputPer1MUsd`, `outputPer1MUsd`) are ignored. The file shape is documented on [Pricing](/llm-usage-metrics/pricing/).
 
 ## Related pages
 
-- [Pricing](/pricing/) — user-facing knobs, cost modes, and row rendering.
-- [Caching](/caching/) — tuning the pricing cache.
-- [Configuration](/configuration/) — the `pricing.*` config keys.
+- [Pricing](/llm-usage-metrics/pricing/) — user-facing knobs, cost modes, and row rendering.
+- [Caching](/llm-usage-metrics/caching/) — tuning the pricing cache.
+- [Configuration](/llm-usage-metrics/configuration/) — the `pricing.*` config keys.

--- a/site/src/content/docs/compare.mdx
+++ b/site/src/content/docs/compare.mdx
@@ -1,0 +1,69 @@
+---
+title: Compare Periods
+description: Compare tokens, cost, events, and active days between two date windows.
+---
+
+`llm-usage compare` summarizes two windows with the same source, provider, model, timezone, history, and pricing settings. It reports the current value, baseline value, absolute delta, and percentage change for each metric.
+
+## Default comparison
+
+```bash
+llm-usage compare
+```
+
+With no date flags, the current window is the current local calendar month and the baseline is the previous calendar month. The report timezone decides those boundaries.
+
+## Compare a chosen range
+
+```bash
+llm-usage compare \
+  --since 2026-06-01 \
+  --until 2026-06-30
+```
+
+An explicit current range needs both `--since` and `--until`. Without baseline flags, the CLI chooses the equal-length window immediately before the current range.
+
+The equal-length rule uses the number of days. A 31-day March range therefore compares with the 31 days ending on the last day of February, rather than with February alone.
+
+## Set both windows
+
+```bash
+llm-usage compare \
+  --since 2026-06-01 \
+  --until 2026-06-30 \
+  --vs-since 2026-04-01 \
+  --vs-until 2026-04-30
+```
+
+`--vs-since` and `--vs-until` must appear together. The two ranges may have different lengths, so check active days before interpreting a raw total change.
+
+## Metrics
+
+The totals section compares:
+
+- all five token buckets and total tokens
+- cost
+- event count
+- active days
+
+The source section compares cost by source. Cost keeps the shared pricing semantics: a tilde marks an incomplete amount, and a missing cost stays unresolved.
+
+A percentage delta is unavailable when the baseline value is zero and the current value is nonzero. Both zero values produce a `0%` change.
+
+## Filter both windows
+
+```bash
+llm-usage compare --source codex --model codex
+llm-usage compare --provider anthropic --history
+```
+
+Filters apply once to the combined dataset before the command separates events into the current and baseline windows. This keeps the scope consistent.
+
+## Export
+
+```bash
+llm-usage compare --json
+llm-usage compare --markdown
+```
+
+Compare supports terminal, JSON, and Markdown. It does not create a share SVG. Diagnostics stay on `stderr` in every format.

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -3,7 +3,7 @@ title: Configuration
 description: Config file, CLI precedence, source path overrides, and runtime environment overrides.
 ---
 
-`llm-usage-metrics` uses a TOML config file for persistent defaults. CLI flags override it for one-off runs, and environment variables provide an override layer for scripts, CI, and debugging. For the design behind this — precedence machinery, validation, the template, and log levels — see the [Config & Logging](/architecture/config-and-logging/) deep dive.
+`llm-usage-metrics` uses a TOML config file for persistent defaults. CLI flags override it for one-off runs, and environment variables provide an override layer for scripts, CI, and debugging. For the design behind this — precedence machinery, validation, the template, and log levels — see the [Config & Logging](/llm-usage-metrics/architecture/config-and-logging/) deep dive.
 
 ## Config file
 
@@ -21,7 +21,7 @@ Config root follows the platform:
 
 Run `llm-usage config init` to write a commented template at the active config path. Set `LLM_USAGE_CONFIG_PATH=/path/to/config.toml` to point at a different config file. A missing config file is silent and uses built-in defaults. Malformed TOML is an error. Unknown keys are reported once on `stderr` and the run continues.
 
-TOML editors such as Taplo can validate the file through the `#:schema` directive. The schema is published at [config-schema.json](/config-schema.json):
+TOML editors such as Taplo can validate the file through the `#:schema` directive. The schema is published at [config-schema.json](/llm-usage-metrics/config-schema.json):
 
 ```toml
 #:schema https://ayagmar.github.io/llm-usage-metrics/config-schema.json

--- a/site/src/content/docs/doctor.mdx
+++ b/site/src/content/docs/doctor.mdx
@@ -30,12 +30,12 @@ llm-usage doctor --json
 
 ## Output
 
-Doctor prints one line per source, then a health summary, then the event store. It exits `0` even when a source is unhealthy, so it is safe to run in scripts.
+Doctor prints one line per source — a `✔`/`✖` health glyph, the source id, its storage format (`jsonl`, `json`, or `sqlite`), and what was found — then a health summary. It exits `0` even when a source is unhealthy, so it is safe to run in scripts.
 
 ```text
-pi           ok     519 file(s)
-opencode     error  OpenCode database is missing or unreadable: /path/to/opencode.db
-event-store  ok     159266 event(s), 3 departed file(s), schema v2, 78.4 MiB
+✔ pi           jsonl   519 file(s)
+✖ opencode     sqlite  OpenCode database is missing or unreadable: /path/to/opencode.db
+✔ event-store  sqlite  159266 event(s), 3 departed file(s), schema v2, 78.4 MiB
 
 15/16 sources healthy
 ```
@@ -44,20 +44,21 @@ The summary counts only source rows; the `event-store` row reports the ledger's 
 
 ## JSON shape
 
-`--json` returns a `sources` array (the `event-store` row is included with a `detail` string):
+`--json` returns a `sources` array. Healthy rows carry `itemsFound` (and the `event-store` row a `detail` string); unhealthy rows carry `error`:
 
 ```json
 {
   "sources": [
-    { "id": "pi", "status": "ok", "itemsFound": 519 },
+    { "id": "pi", "format": "jsonl", "status": "ok", "itemsFound": 519 },
     {
       "id": "opencode",
+      "format": "sqlite",
       "status": "error",
-      "itemsFound": 0,
-      "detail": "OpenCode database is missing or unreadable: /path/to/opencode.db"
+      "error": "OpenCode database is missing or unreadable: /path/to/opencode.db"
     },
     {
       "id": "event-store",
+      "format": "sqlite",
       "status": "ok",
       "itemsFound": 159266,
       "detail": "159266 event(s), 3 departed file(s), schema v2, 78.4 MiB"

--- a/site/src/content/docs/efficiency.mdx
+++ b/site/src/content/docs/efficiency.mdx
@@ -1,121 +1,92 @@
 ---
 title: Efficiency
-description: How efficiency reports are computed, scoped, and interpreted.
+description: Join repo-attributed usage with local Git activity and interpret the ratios carefully.
 ---
 
-Efficiency reporting is the core value proposition of `llm-usage-metrics`. By correlating local Git outcomes with LLM costs, you can derive the true ROI of your AI-assisted development workflow.
+`llm-usage efficiency` places repo-attributed token usage and cost beside your local Git activity. The resulting ratios help with review, but they do not measure code quality, business value, or causal return on investment.
 
-## The ROI Equation
-
-`llm-usage efficiency` joins two high-signal datasets:
-
-1. **Repo-Attributed Usage**: Token counts and costs mapped to your project root.
-2. **Git Outcomes**: Local commit volume and line-delta metrics for your author.
-
-This join allows you to answer questions like: *How much does a commit actually cost in tokens?* and *What is my USD spend per 1k lines of code?*
-
-## Command structure
+## Run the report
 
 ```bash
 llm-usage efficiency <daily|weekly|monthly> [options]
 ```
 
-Examples:
+Start with a monthly view so the raw totals have enough volume to interpret:
 
 ```bash
-llm-usage efficiency daily
-llm-usage efficiency weekly --repo-dir /path/to/repo
-llm-usage efficiency monthly --repo-dir /path/to/repo --json
-llm-usage efficiency monthly --repo-dir /path/to/repo --source codex
+llm-usage efficiency monthly --repo-dir /path/to/repo
+```
+
+Other useful forms:
+
+```bash
+llm-usage efficiency weekly --repo-dir /path/to/repo --json
 llm-usage efficiency monthly --repo-dir /path/to/repo --by-source
 llm-usage efficiency monthly --repo-dir /path/to/repo --share
 ```
 
-`--share` is supported only for `monthly` and writes `efficiency-monthly-share.svg` to the current working directory.
-`--share` cannot be combined with `--by-source`.
+`--share` works for monthly reports and cannot be combined with `--by-source`.
 
-## What is joined
+## What the command joins
 
-Efficiency rows are built from two datasets per period:
+The command builds two datasets for each period:
 
-- repo-attributed usage totals (`Input`, `Output`, `Reasoning`, `Cache Read`, `Cache Write`, `Total`, `Cost`)
-- Git outcomes for your configured author (`Commits`, `+Lines`, `-Lines`, `ΔLines`)
+1. Usage events mapped to the selected repository root through source metadata such as a working directory or file path.
+2. Commits and line changes from local Git history for your configured author.
 
-Only usage events mapped to the selected repository root are included.
+Events without repository attribution stay out of the usage totals. Periods need both Git activity and attributed usage before the renderer emits a row.
 
 ## Column formulas
 
-- `Tokens/Commit` = `(Input + Output + Reasoning) / Commits`
-- `$/Commit` = `Cost / Commits`
-- `$/1k Lines` = `Cost / (ΔLines / 1000)`
-- `Commits/$` = `Commits / Cost` (only when `Cost > 0`)
+| Column | Formula |
+| --- | --- |
+| `Tokens/Commit` | `(Input + Output + Reasoning) / Commits` |
+| `$/Commit` | `Cost / Commits` |
+| `$/1k Lines` | `Cost / (ΔLines / 1000)` |
+| `Commits/$` | `Commits / Cost`, when cost is above zero |
 
-Rendering rules:
+`Tokens/Commit` excludes cache read and cache write tokens. The table keeps those buckets visible in the raw usage columns.
 
-- period rows are emitted only when both Git outcomes and repo-attributed usage signal exist
-- if a denominator is zero, the derived value is `-` (terminal/markdown) or omitted in JSON
-- when pricing is incomplete, affected USD values are approximate (`~` prefix in terminal/markdown)
+A zero denominator renders as `-` in terminal and Markdown output. JSON omits that derived value. Partial pricing adds a `~` prefix to affected USD metrics.
+
+## Read the denominators before the ratios
+
+Review `Commits`, `ΔLines`, and `Cost` first. A small denominator can make a ratio swing even when the underlying usage barely changed.
+
+The ratios also inherit the limits of Git activity:
+
+- A commit and a line delta describe repository activity, not correctness or customer value.
+- Source metadata determines repository attribution. Unattributed events cannot contribute.
+- Filters can change which commit days qualify, so two filtered runs may not share the same Git denominator.
+
+Use the report to spot periods worth investigating. Do not use one ratio as a developer score.
 
 ## Per-source view
-
-Use `--by-source` to show repo-attributed usage rows under each period subtotal:
 
 ```bash
 llm-usage efficiency monthly --repo-dir /path/to/repo --by-source
 ```
 
-Source rows show usage and cost columns only. `Commits`, line deltas, and derived ratios render as `-` because Git outcomes are collected per period for the repository, not per source. The period subtotal keeps the normal efficiency metrics and is the row to use for commit-based ratios.
+Source rows show usage and cost under each period subtotal. Git outcomes belong to the repository period, so source rows display `-` for commits, line changes, and derived ratios. The period subtotal carries those values.
 
-JSON output for `--by-source` returns a payload with `grouping: "source"` and `rows`; default JSON output without `--by-source` remains the rows array.
+JSON with `--by-source` returns `grouping: "source"` and a `rows` array. Default JSON returns the period rows directly.
 
-## Scope and attribution semantics
+## Filters and attribution
 
-### Repository root
-
-- default repo is current working directory
-- override with `--repo-dir`
-- usage events that cannot be mapped to a repo are counted as unattributed and excluded
-
-### Filters
-
-Usage filters apply before efficiency aggregation:
+Usage filters apply before aggregation:
 
 - `--source`
 - `--provider`
 - `--model`
-- source path overrides (`--pi-dir`, `--codex-dir`, `--copilot-dir`, `--gemini-dir`, `--droid-dir`, `--claude-dir`, `--amp-dir`, `--qwen-dir`, `--kimi-dir`, `--cline-dir`, `--roocode-dir`, `--kilocode-dir`, `--antigravity-dir`, `--opencode-db`, `--goose-db`, `--source-dir`)
+- source path overrides
 
-Important: these filters also affect commit attribution. Only commit days with matching repo-attributed usage events are counted in efficiency outcomes.
+These filters also constrain Git attribution. The command counts a commit day only when that day contains a matching repo-attributed usage event.
 
-## Reading results without being misled
-
-- `Tokens/Commit` excludes cache read/write tokens, showing only direct prompt/response/reasoning intensity per commit.
-- Compare `Tokens/Commit` with `$/Commit` to gauge cost-efficiency of your AI workflow.
-
-For filtered source comparisons, run the same command per source:
+For a source-specific comparison, run the same date range and repository with a different source filter:
 
 ```bash
-llm-usage efficiency monthly --repo-dir /path/to/repo --source pi
 llm-usage efficiency monthly --repo-dir /path/to/repo --source codex
-llm-usage efficiency monthly --repo-dir /path/to/repo --source gemini
-llm-usage efficiency monthly --repo-dir /path/to/repo --source droid
-llm-usage efficiency monthly --repo-dir /path/to/repo --source opencode
-llm-usage efficiency monthly --repo-dir /path/to/repo --source openclaw
 llm-usage efficiency monthly --repo-dir /path/to/repo --source claude
-llm-usage efficiency monthly --repo-dir /path/to/repo --source copilot
-llm-usage efficiency monthly --repo-dir /path/to/repo --source goose
-llm-usage efficiency monthly --repo-dir /path/to/repo --source amp
-llm-usage efficiency monthly --repo-dir /path/to/repo --source qwen
-llm-usage efficiency monthly --repo-dir /path/to/repo --source kimi
-llm-usage efficiency monthly --repo-dir /path/to/repo --source cline
-llm-usage efficiency monthly --repo-dir /path/to/repo --source roocode
-llm-usage efficiency monthly --repo-dir /path/to/repo --source kilocode
-llm-usage efficiency monthly --repo-dir /path/to/repo --source antigravity
 ```
 
-## Recommended review workflow
-
-1. Start with monthly for stability.
-2. Check `Commits`, `ΔLines`, and `Cost` first (raw denominators).
-3. Then interpret derived ratios (`$/Commit`, `$/1k Lines`, token/commit metrics).
-4. Drill into source/provider/model filters only after baseline sanity checks.
+Keep the raw denominators beside the ratios when you compare the results.

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -1,172 +1,114 @@
 ---
 title: Getting Started
-description: Install llm-usage-metrics and run your first reports.
+description: Install the CLI, run a local report, and learn where to go next.
 ---
 
-## Install
+You need Node.js 24 or newer and session data from at least one [supported source](/llm-usage-metrics/sources/). The CLI discovers standard source locations, so most first runs need no configuration.
 
-```bash
-npm install -g llm-usage-metrics
-```
+## 1. Run the CLI
 
-Run without global install:
+Try it without installing:
 
 ```bash
 npx --yes llm-usage-metrics@latest daily
 ```
 
-## Requirements
-
-- Node.js 24+
-- At least one supported source:
-  - `.pi` sessions (`~/.pi/agent/sessions/**/*.jsonl`)
-  - `.codex` sessions (`~/.codex/sessions/**/*.jsonl`)
-  - `.gemini` sessions (`~/.gemini/tmp/*/chats/*.json`)
-  - Droid sessions (`~/.factory/sessions/**/*.settings.json`)
-  - OpenCode SQLite DB (auto-discovered or explicit `--opencode-db`, requires built-in `node:sqlite` support)
-  - OpenClaw transcripts (`~/.openclaw/agents/**/*.jsonl`)
-  - Claude Code projects (`~/.claude/projects/**/*.jsonl`)
-  - GitHub Copilot CLI OTEL exports (`~/.copilot/otel/*.jsonl`)
-  - Goose SQLite DB (`~/.local/share/goose/sessions/sessions.db`)
-  - Amp thread files (`~/.local/share/amp/threads/*.json`)
-  - Qwen CLI chats (`~/.qwen/projects/*/chats/*.jsonl`)
-  - Kimi CLI/Kimi Code wire files (`~/.kimi/sessions/**/wire.jsonl`, `~/.kimi-code/sessions/**/wire.jsonl`)
-  - Cline/RooCode/KiloCode task files in VS Code global storage
-  - Antigravity CLI conversation DBs (`~/.gemini/antigravity-cli/conversations/*.db`)
-
-## First report
+Or install the `llm-usage` command:
 
 ```bash
+npm install -g llm-usage-metrics
 llm-usage daily
 ```
 
-Costs are estimated with LiteLLM pricing. First runs work offline from the
-bundled LiteLLM snapshot; online runs refresh the local pricing cache when
-needed. If the bundled snapshot is used, `stderr` shows its snapshot date.
+The first run parses matching session files, stores normalized events in a local SQLite ledger, and loads pricing. Later runs can reuse unchanged files from the ledger.
 
-Useful next commands:
+## 2. Read the table
+
+Each period contains one row per source. A `combined` row appears when the period includes more than one source, and the final `ALL` row totals the full range.
+
+Token columns keep the buckets supplied by each source:
+
+- `Input`, `Output`, and `Reasoning`
+- `Cache Read` and `Cache Write`
+- `Total`, using the source adapter's normalized total
+
+Cost may come from the source or from LiteLLM pricing. A tilde, such as `~$4.82`, marks a partial estimate. A dash means the CLI could not resolve cost for that row. See [Pricing](/llm-usage-metrics/pricing/) for the full rules.
+
+## 3. Scope the result
+
+Use calendar ranges and filters to answer a narrower question:
 
 ```bash
-llm-usage weekly --timezone Europe/Paris
-llm-usage monthly --since 2026-01-01 --until 2026-01-31
-llm-usage trends --metric tokens --days 14
+# A calendar month in your reporting timezone
+llm-usage monthly --since 2026-06-01 --until 2026-06-30
+
+# Only Codex and Claude Code sessions
+llm-usage monthly --source codex,claude
+
+# Sessions billed through OpenAI
+llm-usage monthly --provider openai
+
+# A model name or substring
+llm-usage monthly --model codex
 ```
 
-## Persist your defaults
+`--source` describes where the event came from. `--provider` describes the billing entity behind the model. A Codex session can therefore have `source=codex` and `provider=openai`.
+
+## 4. Choose a closer view
+
+```bash
+# Compare the current local month with the previous month
+llm-usage compare
+
+# Rank conversations by cost
+llm-usage session --top 10
+
+# Chart the last 14 local days
+llm-usage trends --metric tokens --days 14
+
+# Group usage by repository
+llm-usage session --by-repo
+```
+
+Use [Compare](/llm-usage-metrics/compare/) for period changes, [Session](/llm-usage-metrics/session/) for conversation-level detail, and [Trends](/llm-usage-metrics/trends/) for a daily series.
+
+## 5. Save your defaults when you need them
 
 ```bash
 llm-usage config init
 ```
 
-The template ships every key commented out with its default value, and its `#:schema` line enables editor validation. See [Configuration](/configuration/) for all keys.
+The command writes a commented TOML file with the current defaults and a JSON Schema directive for editor validation. Common reasons to edit it include:
 
-## Common filters
+- your sessions live outside a tool's default directory
+- you want a fixed reporting timezone
+- you prefer offline pricing or quieter diagnostics
+
+CLI flags override environment variables, which override the config file. [Configuration](/llm-usage-metrics/configuration/) lists every key and its matching flag.
+
+## If the first report is empty
+
+Run the discovery probe:
 
 ```bash
-llm-usage monthly --source pi,codex,gemini,droid,openclaw,claude,copilot,goose,amp,qwen,kimi,cline,roocode,kilocode,antigravity
-llm-usage monthly --provider openai
-llm-usage monthly --model claude
+llm-usage doctor
 ```
 
-## Output modes
+Doctor reports the location and health of each source without parsing sessions or loading pricing. Probe one source or give it an explicit path when needed:
+
+```bash
+llm-usage doctor --source codex
+llm-usage doctor --source claude --claude-dir /path/to/.claude/projects
+```
+
+The [Data Sources](/llm-usage-metrics/sources/) pages list default locations and override flags. [Troubleshooting](/llm-usage-metrics/troubleshooting/) covers parse failures, missing pricing, and event-store issues.
+
+## Export the result
 
 ```bash
 llm-usage daily --json
 llm-usage daily --markdown
-llm-usage monthly --per-model-columns
-llm-usage monthly --pricing-offline
-llm-usage monthly --ignore-pricing-failures
+llm-usage monthly --share
 ```
 
-## Efficiency quick start
-
-```bash
-llm-usage efficiency monthly
-llm-usage efficiency monthly --repo-dir /path/to/repo --json
-```
-
-See [Efficiency](/efficiency/) for full metric semantics and interpretation rules.
-
-## Trends quick start
-
-```bash
-llm-usage trends
-llm-usage trends --metric tokens --days 7
-llm-usage trends --by-source --json
-```
-
-See [Trends](/trends/) for range rules, metric semantics, and JSON shape.
-
-## Gemini explicit path
-
-```bash
-llm-usage monthly --source gemini --gemini-dir /path/to/.gemini
-```
-
-Use the TOML [config file](/configuration/) to persist source paths instead of
-repeating explicit path flags on every run — run `llm-usage config init` to
-write a commented template.
-
-## OpenCode explicit DB path
-
-```bash
-llm-usage monthly --source opencode --opencode-db /path/to/opencode.db
-```
-
-If no default OpenCode DB is found and no explicit path is given, OpenCode is treated as unavailable for that run.
-
-## Droid explicit path
-
-```bash
-llm-usage monthly --source droid --droid-dir /path/to/.factory/sessions
-```
-
-## Claude explicit path
-
-```bash
-llm-usage monthly --source claude --claude-dir /path/to/.claude/projects
-```
-
-## Copilot explicit path
-
-```bash
-llm-usage monthly --source copilot --copilot-dir /path/to/.copilot/otel
-```
-
-## Goose explicit DB path
-
-```bash
-llm-usage monthly --source goose --goose-db /path/to/goose/sessions.db
-```
-
-## Amp explicit path
-
-```bash
-llm-usage monthly --source amp --amp-dir /path/to/amp/threads
-```
-
-## Qwen explicit path
-
-```bash
-llm-usage monthly --source qwen --qwen-dir /path/to/.qwen/projects
-```
-
-## Kimi explicit path
-
-```bash
-llm-usage monthly --source kimi --kimi-dir /path/to/kimi/sessions
-```
-
-## Cline family explicit paths
-
-```bash
-llm-usage monthly --source cline --cline-dir /path/to/cline/tasks
-llm-usage monthly --source roocode --roocode-dir /path/to/roocode/tasks
-llm-usage monthly --source kilocode --kilocode-dir /path/to/kilocode/tasks
-```
-
-## Antigravity explicit path
-
-```bash
-llm-usage monthly --source antigravity --antigravity-dir /path/to/antigravity/conversations
-```
+Report data goes to `stdout`; diagnostics stay on `stderr`. This separation keeps JSON and Markdown safe to redirect into a file or pipeline. Share support varies by report, so check [Output Formats](/llm-usage-metrics/output-formats/) before adding `--share` to a specialized command.

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,130 +1,92 @@
 ---
 title: Documentation
-description: Complete documentation for llm-usage-metrics CLI.
+description: Understand local LLM usage, pricing, sessions, and reports.
 tableOfContents: false
 ---
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-`llm-usage-metrics` is a local-first CLI that aggregates token usage and estimated cost across 16 coding agents with zero configuration. Everything runs on your machine: session files in, reports out. Pricing works fully offline from a bundled LiteLLM snapshot.
+`llm-usage-metrics` reads session data created by 16 AI coding tools and converts it into one normalized usage history. You can review token volume, estimate cost, find expensive sessions, compare periods, and export the results. The CLI parses session content on your machine.
 
-## What it does
-
-- **16 sources, zero-config discovery** — Claude Code, codex, Gemini CLI, Copilot CLI, Cline, Goose, and more, each with an explicit path override.
-- **Reports** — `daily` / `weekly` / `monthly`, `compare` (period vs period), `trends`, `session` (per-conversation cost), `wrapped` (yearly recap), `efficiency` (git-attributed cost per commit), `optimize` (counterfactual model pricing), `doctor`, `prune`.
-- **SQLite event-store ledger** — warm re-runs skip reparsing, `--history` reports files that left the disk, content-hash move suppression, and explicit `prune` maintenance.
-- **TOML config** — `llm-usage config init` writes a commented-defaults template with a published JSON schema; precedence is flags → env → config → defaults, with `logLevel` and `--quiet`.
-- **Offline-first pricing** — LiteLLM pricing resolves cache → network → stale cache → bundled snapshot.
-- **Output** — terminal tables, JSON, Markdown, and share SVGs (usage, trends, wrapped, efficiency, optimize).
-- **Measured performance** — cold runs parse a 1.8 GiB codex corpus in ~1.7 s; warm runs return in ~0.26 s (claude) to ~1.0 s (codex) on the same data. See [Benchmarks](/benchmarks/) for methodology.
-
-## Quick Start
+## Run your first report
 
 ```bash
-# Install globally (or run via: npx llm-usage-metrics@latest daily)
-npm install -g llm-usage-metrics
-
-# First report
-llm-usage daily
-
-# Persist defaults in a commented TOML template
-llm-usage config init
-
-# Dig deeper
-llm-usage session
-llm-usage compare
+npx --yes llm-usage-metrics@latest daily
 ```
 
-## Supported sources
+The command discovers supported sources in their default locations. Use `llm-usage doctor` if the report finds no data, or create a config file when your sessions live elsewhere.
 
-| Source      | Reads from                                                     |
-| ----------- | -------------------------------------------------------------- |
-| pi          | `~/.pi/agent/sessions` JSONL (+ `~/.omp/agent/sessions`)       |
-| codex       | `~/.codex/sessions` JSONL                                      |
-| Gemini CLI  | `~/.gemini/tmp/*/chats` JSON                                   |
-| Droid CLI   | `~/.factory/sessions` settings JSON                            |
-| OpenCode    | `~/.local/share/opencode` SQLite DB                            |
-| OpenClaw    | `~/.openclaw/agents` JSONL (+ legacy homes)                    |
-| Claude Code | `~/.claude/{projects,transcripts}` JSONL                       |
-| Copilot CLI | `~/.copilot/otel` OTEL JSONL                                   |
-| Goose       | `~/.local/share/goose/sessions` SQLite DB                      |
-| Amp         | `~/.local/share/amp/threads` JSON                              |
-| Qwen CLI    | `~/.qwen/projects/*/chats` JSONL                               |
-| Kimi        | `~/.kimi` / `~/.kimi-code` wire JSONL                          |
-| Cline       | VS Code global storage task files                              |
-| RooCode     | VS Code global storage task files                              |
-| KiloCode    | VS Code global storage task files                              |
-| Antigravity | `~/.gemini/antigravity-cli/conversations` SQLite DBs           |
+```bash
+llm-usage doctor
+llm-usage config init
+```
 
-SQLite-backed sources (OpenCode, Goose, Antigravity) require Node.js 24+ with built-in `node:sqlite`.
+## Pick the report by question
 
-## Quick Navigation
+| Question | Command |
+| --- | --- |
+| How many tokens and dollars did I use? | `daily`, `weekly`, `monthly` |
+| How did this period change from the last one? | `compare` |
+| Which conversations or repositories used the most? | `session` |
+| How is usage moving day by day? | `trends` |
+| How does repo-attributed usage line up with Git activity? | `efficiency` |
+| What would the same token mix cost on another model? | `optimize` |
+| Which sources can the CLI see? | `doctor` |
+| Which departed files can I remove from the event ledger? | `prune` |
+| How did the year add up? | `wrapped` |
+
+## How the CLI handles your numbers
+
+Source adapters normalize input, output, reasoning, cache read, and cache write tokens at the file boundary. The pricing engine keeps an explicit source cost when one exists. Otherwise, it estimates cost from LiteLLM pricing.
+
+Reports show the difference:
+
+- `$12.34` means every contributing event has a resolved cost.
+- `~$12.34` means the known cost is partial.
+- `-` means the CLI could not price any contributing event.
+
+The bundled pricing snapshot lets the first report run offline. An online run may refresh the pricing cache from LiteLLM. Pricing requests never include session content.
+
+## What stays on your machine
+
+The CLI reads local session files and local Git history. It writes its event ledger and caches under your platform cache directory. Two optional network requests remain separate from your usage data:
+
+- a cached npm version check at startup
+- a LiteLLM pricing refresh when the pricing cache is stale
+
+Use `--pricing-offline` and `LLM_USAGE_SKIP_UPDATE_CHECK=1` when you want a report with no network requests.
+
+## Continue from here
 
 <CardGrid>
   <LinkCard
-    title="Getting Started"
-    description="Zero-config installation and your first report in seconds."
+    title="Getting started"
+    description="Install the CLI, read the first table, and choose the next useful report."
     href="/llm-usage-metrics/getting-started/"
   />
   <LinkCard
-    title="CLI Reference"
-    description="Complete command and option reference."
-    href="/llm-usage-metrics/cli-reference/"
-  />
-  <LinkCard
-    title="Data Sources"
-    description="Discovery details and override flags for all 16 source adapters."
+    title="Data sources"
+    description="Check default locations, file formats, and path overrides for all 16 adapters."
     href="/llm-usage-metrics/sources/"
   />
   <LinkCard
-    title="Configuration"
-    description="The TOML config file, llm-usage config init, and every key."
-    href="/llm-usage-metrics/configuration/"
+    title="CLI reference"
+    description="Use the generated command and option reference when you know the flag you need."
+    href="/llm-usage-metrics/cli-reference/"
   />
   <LinkCard
-    title="Efficiency"
-    description="Correlate Git outcomes with LLM costs in your repositories."
-    href="/llm-usage-metrics/efficiency/"
+    title="Pricing"
+    description="See where rates come from and how complete, partial, and missing cost render."
+    href="/llm-usage-metrics/pricing/"
   />
   <LinkCard
-    title="Optimize"
-    description="Replay your usage token mix against candidate model pricing."
-    href="/llm-usage-metrics/optimize/"
-  />
-  <LinkCard
-    title="Sessions"
-    description="Per-conversation cost, grouped by session or repository."
-    href="/llm-usage-metrics/session/"
-  />
-  <LinkCard
-    title="Wrapped"
-    description="A yearly usage recap with an optional share SVG."
-    href="/llm-usage-metrics/wrapped/"
-  />
-  <LinkCard
-    title="Benchmarks"
-    description="Measured cold and warm runtimes on real local data, with methodology."
-    href="/llm-usage-metrics/benchmarks/"
+    title="Output formats"
+    description="Choose terminal, JSON, Markdown, or a supported share SVG."
+    href="/llm-usage-metrics/output-formats/"
   />
   <LinkCard
     title="Architecture"
-    description="How parsing, pricing, and the event store fit together."
+    description="Follow discovery, parsing, pricing, aggregation, and rendering through the codebase."
     href="/llm-usage-metrics/architecture/"
   />
-  <LinkCard
-    title="Security"
-    description="See the repo's current security controls and contributor security steps."
-    href="/llm-usage-metrics/security/"
-  />
 </CardGrid>
-
-## Key Commands
-
-```bash
-llm-usage daily
-llm-usage compare
-llm-usage session --by-repo
-llm-usage wrapped --share
-llm-usage efficiency monthly --repo-dir ./my-project
-llm-usage optimize monthly --provider openai --candidate-model gpt-5-codex
-```

--- a/site/src/content/docs/output-formats.mdx
+++ b/site/src/content/docs/output-formats.mdx
@@ -1,139 +1,67 @@
 ---
 title: Output Formats
-description: Terminal, JSON, and Markdown output modes.
+description: Choose terminal, JSON, Markdown, or a supported share SVG.
 ---
 
-## Terminal (default)
+The CLI keeps report data on `stdout` and diagnostics on `stderr`. Redirecting JSON or Markdown therefore produces a clean data file while discovery and pricing notes remain visible in the terminal.
+
+## Terminal
 
 ```bash
 llm-usage daily
 ```
 
-Terminal output includes:
+The default renderer uses a boxed title and a Unicode table. `NO_COLOR=1` removes ANSI color without changing the content.
 
-- boxed report header
-- semantic header colors and source-aware row styling
-- summary-row emphasis for combined and grand totals
-- diagnostics on `stderr`
-- data table on `stdout`
+Very wide usage tables can emit an overflow warning on `stderr`. Use a wider terminal, filter the report, or switch to JSON when you need every column without terminal wrapping.
 
 ## JSON
 
 ```bash
-llm-usage daily --json
+llm-usage daily --json > usage.json
 ```
 
-Use for scripting and automation pipelines.
+Use JSON for scripts and pipelines. Specialized reports keep their own documented shape, so read the report page before depending on fields. Diagnostics never enter the JSON body.
 
 ## Markdown
 
 ```bash
-llm-usage daily --markdown
+llm-usage daily --markdown > usage.md
 ```
 
-Use for docs, changelogs, and issue/PR reporting.
+Markdown works for usage, compare, session, efficiency, and optimize reports. It does not work for trends, wrapped, doctor, or prune.
 
-Usage report tables rank per-period models by total tokens so the dominant models appear first in both terminal and Markdown output.
+Usage and session output keep the same ordering and row limits as the terminal renderer. `--per-model-columns` also works with Markdown usage reports.
 
 ## Share SVG
 
-Generate a dark-themed share image:
+Share output is an offline SVG written to the current directory. The command still prints the normal report to `stdout`.
 
-```bash
-# Usage reports (daily, weekly, or monthly)
-llm-usage monthly --share
-llm-usage daily --share
-llm-usage weekly --share
+| Report | Command | File |
+| --- | --- | --- |
+| Usage | `llm-usage monthly --share` | `usage-monthly-share.svg` |
+| Trends | `llm-usage trends --share` | `trends-share.svg` |
+| Wrapped | `llm-usage wrapped --year 2026 --share` | `llm-usage-wrapped-2026.svg` |
+| Efficiency | `llm-usage efficiency monthly --share` | `efficiency-monthly-share.svg` |
+| Optimize | `llm-usage optimize monthly --candidate-model gpt-4.1 --share` | `optimize-monthly-share.svg` |
 
-# Efficiency (monthly only)
-llm-usage efficiency monthly --repo-dir /path/to/repo --share
+Usage share works for daily, weekly, and monthly reports. Efficiency and optimize share work for monthly reports only. Trends share requires the combined view, so it cannot be paired with `--by-source`. Efficiency share cannot be paired with `--by-source` either.
 
-# Optimize (monthly only)
-llm-usage optimize monthly --provider openai --candidate-model gpt-4.1 --share
-```
-
-`--share` writes an SVG file to the current directory:
-
-- Usage reports: `usage-{granularity}-share.svg` (stacked area chart by source)
-- Efficiency: `efficiency-monthly-share.svg` (commit bars + $/commit line)
-- Optimize: `optimize-monthly-share.svg` (savings % heatmap)
-
-All share images use a dark theme designed for social media sharing.
-
-## Efficiency reports
-
-```bash
-llm-usage efficiency daily
-llm-usage efficiency weekly --repo-dir /path/to/repo --json
-llm-usage efficiency monthly --repo-dir /path/to/repo --share
-```
-
-Efficiency outputs include usage totals, Git outcomes (`Commits`, `+Lines`, `-Lines`, `ΔLines`), and derived ratios.
-
-Usage values are repo-attributed: only usage events mapped to the selected repository root are included.
-
-Columns:
-
-- `Input`, `Output`, `Reasoning`, `Cache Read`, `Cache Write`, `Total`, `Cost` come from repo-attributed usage events.
-- `Commits`, `+Lines`, `-Lines`, `ΔLines` come from local Git shortstat outcomes for the configured Git author.
-- `Tokens/Commit` = `(Input + Output + Reasoning) / Commits` (excludes cache read/write tokens).
-- `$/Commit` = `Cost / Commits`.
-- `$/1k Lines` = `Cost / (ΔLines / 1000)`.
-- `Commits/$` = `Commits / Cost` (only when `Cost > 0`).
-
-Efficiency period rows are emitted only when both Git outcomes and repo-attributed usage signal exist for that period.
-When a denominator is zero, derived values render as `-` in terminal/markdown and are omitted in JSON.
-When pricing is incomplete, affected USD values are prefixed with `~` in terminal/markdown.
-
-Usage filters (`--source`, `--provider`, `--model`, source-path overrides) also affect commit attribution: only commit days with matching repo-attributed usage events are counted.
-`--provider` scopes by billing entity (for example, `openai-codex` is normalized to `openai`).
-
-For deeper semantics (repo attribution, scope behavior, and interpretation guidance), see the [Efficiency](/efficiency/) page.
-
-`--share` is monthly-only for efficiency (see [Share SVG](#share-svg) above).
-
-## Optimize reports
-
-```bash
-llm-usage optimize monthly --provider openai --candidate-model gpt-4.1 --candidate-model gpt-5-codex
-llm-usage optimize weekly --provider openai --candidate-model gpt-4.1,gpt-5-codex --top 1 --json
-llm-usage optimize monthly --provider openai --candidate-model gpt-4.1 --candidate-model gpt-5-codex --share
-```
-
-Optimize output contains baseline and candidate rows per period:
-
-- baseline rows: observed token totals and baseline cost
-- candidate rows: hypothetical cost on each candidate model, savings delta, and notes for missing pricing/incomplete baselines
-
-For JSON and Markdown, `stdout` includes only the report body; diagnostics and warnings remain on `stderr`.
-
-`--share` is monthly-only for optimize (see [Share SVG](#share-svg) above).
-
-## Trends reports
-
-```bash
-llm-usage trends
-llm-usage trends --metric tokens --days 7
-llm-usage trends --by-source --json
-```
-
-- Default terminal output renders a daily trend chart.
-- `--json` emits structured trend series (`metric`, `dateRange`, `totalSeries`, optional `sourceSeries`).
-- Diagnostics stay on `stderr`.
-- Markdown is not supported for this command.
+Compare, session, doctor, and prune do not support `--share`.
 
 ## Per-model columns
-
-Detailed multiline metrics per model:
 
 ```bash
 llm-usage monthly --per-model-columns
 llm-usage monthly --markdown --per-model-columns
 ```
 
-When model breakdowns are present, rows are ordered by descending total tokens before the final `Σ TOTAL` line.
+This usage-report option expands token and cost values per model into aligned multiline cells. Models are ranked by total tokens inside each row.
 
-## stdout/stderr behavior
+## Keep diagnostics separate
 
-- `stdout`: report body (`terminal`, `json`, or `markdown`)
-- `stderr`: diagnostics (session summary, parse failures, skipped rows, pricing source)
+```bash
+llm-usage daily --json > usage.json 2> usage.log
+```
+
+`usage.json` contains report data. `usage.log` contains source discovery, skipped-row, pricing, config, and runtime notes. Pass `--quiet` when you want to suppress informational diagnostics while keeping warnings.

--- a/site/src/content/docs/pricing.mdx
+++ b/site/src/content/docs/pricing.mdx
@@ -3,7 +3,7 @@ title: Pricing
 description: How pricing is loaded and how row costs are computed.
 ---
 
-`llm-usage-metrics` uses LiteLLM pricing data to estimate costs when events do not include explicit cost. For the design behind these knobs — the fallback ladder, model-name matching, and the cost engine — see the [Pricing Pipeline](/architecture/pricing-pipeline/) deep dive.
+`llm-usage-metrics` uses LiteLLM pricing data to estimate costs when events do not include explicit cost. For the design behind these knobs — the fallback ladder, model-name matching, and the cost engine — see the [Pricing Pipeline](/llm-usage-metrics/architecture/pricing-pipeline/) deep dive.
 
 ## Pricing source
 
@@ -33,7 +33,7 @@ When `pricing.offline: true` is set in the config file, there is no
 config for that run (`LLM_USAGE_CONFIG_PATH=/nonexistent llm-usage monthly`) or
 edit the config.
 
-For cache lifecycle and tuning knobs, see [Caching](/caching/).
+For cache lifecycle and tuning knobs, see [Caching](/llm-usage-metrics/caching/).
 
 ## Cost modes
 

--- a/site/src/content/docs/sources/index.mdx
+++ b/site/src/content/docs/sources/index.mdx
@@ -1,65 +1,78 @@
 ---
 title: Data Sources
+description: Default locations, formats, and path overrides for all 16 source adapters.
 ---
 
-`llm-usage-metrics` supports sixteen built-in sources:
+Each adapter owns discovery and source-specific parsing. After parsing, every adapter returns the same normalized `UsageEvent` shape, so reports and filters behave the same across tools.
 
-- `pi`
-- `codex`
-- `gemini`
-- `droid`
-- `opencode`
-- `openclaw`
-- `claude`
-- `copilot`
-- `goose`
-- `amp`
-- `qwen`
-- `kimi`
-- `cline`
-- `roocode`
-- `kilocode`
-- `antigravity`
+## Supported sources
 
-Each source is parsed by a dedicated adapter and normalized into the same `UsageEvent` schema before pricing/aggregation.
+| Source | Local format | Default location |
+| --- | --- | --- |
+| pi | JSONL | `~/.pi/agent/sessions` and `~/.omp/agent/sessions` |
+| codex | JSONL | `~/.codex/sessions` |
+| Gemini CLI | JSON | `~/.gemini/tmp/*/chats` |
+| Droid CLI | settings JSON | `~/.factory/sessions` |
+| OpenCode | SQLite | platform data directory, including `opencode-<channel>.db` |
+| OpenClaw | JSONL | `~/.openclaw/agents` and supported legacy homes |
+| Claude Code | JSONL | `~/.claude/projects` and `~/.claude/transcripts` |
+| Copilot CLI | OTEL JSONL | `~/.copilot/otel` |
+| Goose | SQLite | platform Goose data directory |
+| Amp | JSON | `~/.local/share/amp/threads` |
+| Qwen CLI | JSONL | `~/.qwen/projects` |
+| Kimi | wire JSONL | `~/.kimi/sessions` and `~/.kimi-code/sessions` |
+| Cline | task JSON | VS Code global storage for `saoudrizwan.claude-dev` |
+| RooCode | task JSON | VS Code global storage for `rooveterinaryinc.roo-cline` |
+| KiloCode | task JSON | VS Code global storage for `kilocode.kilo-code` |
+| Antigravity | SQLite | `~/.gemini/antigravity-cli/conversations` |
 
-## Discovery model
+SQLite-backed sources use the built-in `node:sqlite` module and require Node.js 24 or newer.
 
-- `pi` and `codex`: recursive JSONL discovery in their session directories (`pi` also scans the Oh-My-Pi home `~/.omp/agent/sessions`)
-- `gemini`: JSON session discovery under `~/.gemini/tmp/*/chats/*.json` (or `$GEMINI_CLI_HOME`, or `--gemini-dir`)
-- `droid`: session settings discovery under `~/.factory/sessions/**/*.settings.json` (or `--droid-dir`)
-- `opencode`: single SQLite DB (auto-discovered, including `opencode-<channel>.db` variants, or explicit `--opencode-db`)
-- `openclaw`: recursive JSONL discovery under `~/.openclaw/agents/**/*.jsonl` (plus legacy `~/.clawdbot`/`~/.moltbot`/`~/.moldbot` homes)
-- `claude`: recursive JSONL discovery under `~/.claude/{projects,transcripts}/**/*.jsonl` (or `--claude-dir`)
-- `copilot`: GitHub Copilot CLI OTEL JSONL discovery under `~/.copilot/otel/*.jsonl` (or `--copilot-dir`)
-- `goose`: SQLite session DB discovery under `~/.local/share/goose/sessions/sessions.db` or `$GOOSE_PATH_ROOT/data/sessions/sessions.db` (or `--goose-db`)
-- `amp`: JSON thread discovery under `~/.local/share/amp/threads/*.json` (or `--amp-dir`)
-- `qwen`: recursive JSONL discovery under `~/.qwen/projects/**/*.jsonl` (or `--qwen-dir`)
-- `kimi`: `wire.jsonl` discovery under `~/.kimi/sessions` and `~/.kimi-code/sessions` (or `--kimi-dir`)
-- `cline`: VS Code global storage task discovery for `saoudrizwan.claude-dev` (or `--cline-dir`)
-- `roocode`: VS Code global storage task discovery for `rooveterinaryinc.roo-cline` (or `--roocode-dir`)
-- `kilocode`: VS Code global storage task discovery for `kilocode.kilo-code` (or `--kilocode-dir`)
-- `antigravity`: SQLite conversation DB discovery under `~/.gemini/antigravity-cli/conversations/*.db` or `$GEMINI_CLI_HOME/antigravity-cli/conversations/*.db` (or `--antigravity-dir`)
-
-## Source filtering
+## Check what the CLI can see
 
 ```bash
-llm-usage monthly --source pi
-llm-usage monthly --source pi,codex,gemini,droid,openclaw,claude,copilot,goose,amp,qwen,kimi,cline,roocode,kilocode,antigravity
-llm-usage monthly --source gemini --gemini-dir /path/to/.gemini
-llm-usage monthly --source droid --droid-dir /path/to/.factory/sessions
-llm-usage monthly --source opencode --opencode-db /path/to/opencode.db
-llm-usage monthly --source openclaw --source-dir openclaw=/path/to/.openclaw/agents
-llm-usage monthly --source claude --claude-dir /path/to/.claude/projects
-llm-usage monthly --source copilot --copilot-dir /path/to/.copilot/otel
-llm-usage monthly --source goose --goose-db /path/to/goose/sessions.db
-llm-usage monthly --source amp --amp-dir /path/to/amp/threads
-llm-usage monthly --source qwen --qwen-dir /path/to/.qwen/projects
-llm-usage monthly --source kimi --kimi-dir /path/to/kimi/sessions
-llm-usage monthly --source cline --cline-dir /path/to/cline/tasks
-llm-usage monthly --source roocode --roocode-dir /path/to/roocode/tasks
-llm-usage monthly --source kilocode --kilocode-dir /path/to/kilocode/tasks
-llm-usage monthly --source antigravity --antigravity-dir /path/to/antigravity/conversations
+llm-usage doctor
+llm-usage doctor --source codex,claude
 ```
 
-See per-source pages for details.
+Doctor checks discovery without parsing session contents or loading pricing. Use it before adding overrides: an empty report can also result from date, provider, or model filters.
+
+## Override a location
+
+Directory-backed sources accept a named flag and the generic repeatable form:
+
+```bash
+llm-usage monthly --codex-dir /path/to/codex/sessions
+llm-usage monthly --source-dir codex=/path/to/codex/sessions
+```
+
+SQLite sources use their database flags:
+
+```bash
+llm-usage monthly --opencode-db /path/to/opencode.db
+llm-usage monthly --goose-db /path/to/goose/sessions.db
+```
+
+Persist paths in the TOML config when you use them often:
+
+```toml
+[sourceDirs]
+codex = "/path/to/codex/sessions"
+claude = "/path/to/claude/projects"
+opencode = "/path/to/opencode.db"
+```
+
+CLI flags win over config values. [Configuration](/llm-usage-metrics/configuration/) documents the full precedence order.
+
+## Filter by source
+
+```bash
+llm-usage monthly --source codex
+llm-usage monthly --source codex,claude,opencode
+```
+
+The source identifies the tool that wrote the session. It does not identify the billing provider. Use `--provider openai`, for example, when you want events billed through OpenAI across multiple source tools.
+
+## Adapter details
+
+The pages in this section document each source's discovery roots, parsed record types, token semantics, repository attribution, and explicit path behavior. Those details matter when a source's own dashboard disagrees with a report because the two products may normalize tokens differently.

--- a/site/src/content/docs/trends.mdx
+++ b/site/src/content/docs/trends.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trends
-description: Daily cost or token trends in terminal or JSON form.
+description: Chart daily cost or token usage in the terminal, JSON, or a share SVG.
 ---
 
 `trends` shows daily movement over time instead of a tabular aggregate.
@@ -23,6 +23,9 @@ llm-usage trends --since 2026-02-01 --until 2026-02-28
 
 # Per-source JSON output
 llm-usage trends --by-source --json
+
+# Write the combined series as an SVG
+llm-usage trends --days 14 --share
 ```
 
 ## Options
@@ -30,9 +33,10 @@ llm-usage trends --by-source --json
 - `--days <n>`: trailing local calendar days to chart
 - `--metric <name>`: `cost` or `tokens`
 - `--by-source`: render one sparkline row per source
-- shared filters apply: `--source`, `--provider`, `--model`, `--since`, `--until`, `--timezone`, source-path overrides, and pricing flags
+- `--share`: write the combined series to `trends-share.svg`
+- shared filters apply: `--source`, `--provider`, `--model`, `--since`, `--until`, `--timezone`, source-path overrides, pricing flags, and `--history`
 
-`trends` supports terminal output and `--json`. It does not support `--markdown` or `--share`.
+`trends` supports terminal output, `--json`, and `--share`. It does not support `--markdown`. The share renderer needs the combined series, so `--share` cannot be combined with `--by-source`.
 
 ## `--days` vs `--since` / `--until`
 

--- a/site/src/content/docs/wrapped.mdx
+++ b/site/src/content/docs/wrapped.mdx
@@ -3,7 +3,7 @@ title: Wrapped Recap
 description: A yearly usage recap in the terminal and as a shareable SVG.
 ---
 
-`llm-usage wrapped` condenses a full year of local usage into a single recap: totals, active days, the longest daily streak, the top models and sources, and a month-by-month intensity strip.
+`llm-usage wrapped` condenses a full year of local usage into a single recap: totals, active days, the longest daily streak, the top models and sources, a month-by-month intensity strip in the terminal, and a day-by-day activity heatmap in the share SVG.
 
 ## Command structure
 
@@ -61,7 +61,7 @@ The report uses the shared boxed header, tables, and color policy; set `NO_COLOR
 
 ## Share SVG
 
-`--share` writes an offline SVG named `llm-usage-wrapped-<year>.svg` to the current working directory (its top lists show three rows). PNG rendering and embedded logo/font assets are intentionally out of scope.
+`--share` writes an offline SVG named `llm-usage-wrapped-<year>.svg` to the current working directory. It shows the stat tiles, the top three models and sources, and a GitHub-style daily activity heatmap: one cell per day of the year, shaded by quartile of your active days so a single outlier day does not flatten the rest. PNG rendering and embedded logo/font assets are intentionally out of scope.
 
 ## JSON shape
 
@@ -80,6 +80,9 @@ The report uses the shared boxed header, tables, and color policy; set `NO_COLOR
   "sessionCount": 512,
   "topModels": [{ "name": "gpt-5.1", "totalTokens": 21400000, "costUsd": 96.2 }],
   "topSources": [{ "name": "codex", "totalTokens": 26300000, "costUsd": 121.4 }],
-  "monthlyIntensity": [{ "month": "2026-01", "totalTokens": 2000000, "level": 2 }]
+  "monthlyIntensity": [{ "month": "2026-01", "totalTokens": 2000000, "level": 2 }],
+  "dailyIntensity": [{ "date": "2026-01-01", "totalTokens": 120000, "level": 2 }]
 }
 ```
+
+`dailyIntensity` carries one entry per day of the year (inactive days included at level `0`). Active days are banded into quartile levels `1`–`4`, which is what the share SVG heatmap renders.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -19,56 +19,105 @@ const npmUrl = 'https://www.npmjs.com/package/llm-usage-metrics';
 const reportGroups = [
   {
     number: '01',
+    label: 'Usage',
     question: 'How much did I use?',
     answer: 'Roll up tokens and estimated cost by day, week, or month. Compare two windows or chart a daily trend.',
     commands: ['daily', 'weekly', 'monthly', 'compare', 'trends'],
   },
   {
     number: '02',
+    label: 'Sessions',
     question: 'Which work used the most?',
     answer: 'Rank conversations by cost, inspect a matching session ID, or group the same history by repository.',
     commands: ['session', 'session --by-repo'],
   },
   {
     number: '03',
+    label: 'Efficiency',
     question: 'How does usage line up with Git?',
     answer: 'Join repo-attributed usage with your commits and line changes. Use the ratios as review signals, with the raw denominators beside them.',
     commands: ['efficiency monthly'],
   },
   {
     number: '04',
+    label: 'Optimize',
     question: 'What would another model cost?',
     answer: 'Replay the token mix you observed against candidate pricing without changing your source data.',
     commands: ['optimize monthly'],
   },
   {
     number: '05',
+    label: 'Health',
     question: 'Is my local data healthy?',
     answer: 'Probe every discovery path, inspect the event ledger, and preview retained-history cleanup before deleting anything.',
     commands: ['doctor', 'prune'],
   },
   {
     number: '06',
+    label: 'Wrapped',
     question: 'What did the year look like?',
     answer: 'Summarize active days, streaks, models, sources, tokens, and estimated cost in one terminal recap or SVG.',
     commands: ['wrapped'],
   },
 ];
 
-const sourceGroups = [
+const doctorSources = [
+  { name: 'claude', format: 'jsonl' },
+  { name: 'codex', format: 'jsonl' },
+  { name: 'pi', format: 'jsonl' },
+  { name: 'openclaw', format: 'jsonl' },
+  { name: 'copilot', format: 'jsonl' },
+  { name: 'qwen', format: 'jsonl' },
+  { name: 'kimi', format: 'jsonl' },
+  { name: 'gemini', format: 'json' },
+  { name: 'droid', format: 'json' },
+  { name: 'amp', format: 'json' },
+  { name: 'cline', format: 'json' },
+  { name: 'roocode', format: 'json' },
+  { name: 'kilocode', format: 'json' },
+  { name: 'opencode', format: 'sqlite' },
+  { name: 'goose', format: 'sqlite' },
+  { name: 'antigravity', format: 'sqlite' },
+];
+
+const pipelineStages = [
   {
-    format: 'JSONL',
-    sources: ['pi', 'codex', 'OpenClaw', 'Claude Code', 'Copilot CLI', 'Qwen CLI', 'Kimi'],
+    name: 'discover',
+    detail: 'Find each tool’s local data in its default location, or the paths in your TOML config.',
   },
   {
-    format: 'JSON',
-    sources: ['Gemini CLI', 'Droid CLI', 'Amp', 'Cline', 'RooCode', 'KiloCode'],
+    name: 'normalize',
+    detail: 'Convert source-specific records into one deterministic usage-event shape.',
   },
   {
-    format: 'SQLite',
-    sources: ['OpenCode', 'Goose', 'Antigravity'],
+    name: 'price',
+    detail: 'Keep explicit cost when a tool recorded it; estimate the rest from cached LiteLLM data.',
+  },
+  {
+    name: 'report',
+    detail: 'Aggregate once, then render terminal tables, JSON, Markdown, or SVG.',
   },
 ];
+
+// Deterministic pseudo-random activity levels for the illustrative year heatmap.
+const heatRand = (i: number) => {
+  const x = Math.sin(i * 12.9898 + 78.233) * 43758.5453;
+  return x - Math.floor(x);
+};
+const HEAT_WEEKS = 52;
+const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
+  const week = Math.floor(i / 7);
+  const day = i % 7;
+  const weekday = day < 5;
+  const r = heatRand(i);
+  const hotWeek = heatRand(week * 7.13) > 0.62;
+  let level = 0;
+  if (r > (weekday ? 0.38 : 0.72)) level = 1;
+  if (r > (weekday ? 0.6 : 0.86)) level = 2;
+  if (hotWeek && r > 0.5) level = 3;
+  if (hotWeek && r > 0.78) level = 4;
+  return level;
+});
 ---
 
 <StarlightPage
@@ -82,6 +131,19 @@ const sourceGroups = [
   <div class="page-grid" aria-hidden="true"></div>
 
   <main class="landing">
+    <nav class="page-nav" aria-label="Landing page">
+      <a class="page-nav-brand" href={base}>
+        <span class="brand-prompt" aria-hidden="true">&gt;_</span>
+        <span>llm-usage</span>
+      </a>
+      <div class="page-nav-links">
+        <a href="#reports">Reports</a>
+        <a href="#sources">Sources</a>
+        <a href={link('getting-started/')}>Docs</a>
+      </div>
+      <a class="page-nav-cta" href={link('getting-started/')}>Start locally <span aria-hidden="true">&#8599;</span></a>
+    </nav>
+
     <section class="hero" aria-labelledby="hero-title">
       <div class="hero-copy">
         <a
@@ -94,16 +156,16 @@ const sourceGroups = [
           Version {packageVersion}
         </a>
 
-        <p class="eyebrow">Local usage intelligence for AI coding tools</p>
-        <h1 id="hero-title">See how your coding agents use tokens.</h1>
+        <p class="eyebrow">~/.claude&ensp;·&ensp;~/.codex&ensp;·&ensp;~/.gemini&ensp;·&ensp;13 more</p>
+        <h1 id="hero-title">Your coding agents leave <span>receipts.</span></h1>
         <p class="hero-summary">
-          Read local sessions from 16 tools, normalize usage and pricing, and turn the result
-          into reports you can inspect, compare, or export. Your session data stays on your
-          machine.
+          Sixteen coding tools already write session logs to your disk. <strong>llm-usage</strong>{' '}
+          reads them in place, prices what it can — and marks what it can’t — then turns the
+          result into reports you can inspect, compare, and export. Nothing leaves your machine.
         </p>
 
         <div class="hero-actions">
-          <a class="button button-primary" href={link('getting-started/')}>Start with one report</a>
+          <a class="button button-primary" href={link('getting-started/')}>Get your first report</a>
           <a
             class="button button-secondary"
             href={githubUrl}
@@ -127,76 +189,58 @@ const sourceGroups = [
         <p class="sr-only" aria-live="polite" data-copy-status></p>
       </div>
 
-      <div class="report-preview" aria-label="Shortened example of a monthly usage report">
-        <div class="preview-header">
-          <div>
-            <span class="preview-kicker label">Example output</span>
-            <span class="preview-title">monthly usage</span>
-          </div>
-          <span class="preview-status label">local</span>
+      <div class="terminal-stage">
+        <div class="terminal-glow" aria-hidden="true"></div>
+        <div class="floating-stat floating-stat-top" aria-hidden="true">
+          <span>this month</span>
+          <strong>$86.40</strong>
+          <small>estimated total</small>
         </div>
-
-        <div class="preview-command font-mono">
-          <span aria-hidden="true">$</span> llm-usage monthly --source codex,claude
+        <div class="floating-stat floating-stat-bottom" aria-hidden="true">
+          <span class="live-dot"></span>
+          <strong>local only</strong>
+          <small>no session uploads</small>
         </div>
-
-        <div class="preview-table" role="table" aria-label="Usage report sample">
-          <div class="preview-row preview-table-head" role="row">
-            <span role="columnheader">Source</span>
-            <span role="columnheader">Models</span>
-            <span role="columnheader">Tokens</span>
-            <span role="columnheader">Cost</span>
+        <div class="terminal" aria-label="Recording of a monthly usage report in a terminal">
+          <div class="terminal-bar">
+            <span class="terminal-dots" aria-hidden="true"><i></i><i></i><i></i></span>
+            <span class="terminal-title">~ llm-usage</span>
+            <span class="terminal-badge">local</span>
           </div>
-          <div class="preview-row" role="row">
-            <span class="source-name" role="cell">codex</span>
-            <span role="cell">2 models</span>
-            <span role="cell">91.4M</span>
-            <span role="cell">$54.12</span>
-          </div>
-          <div class="preview-row" role="row">
-            <span class="source-name" role="cell">claude</span>
-            <span role="cell">2 models</span>
-            <span role="cell">51.4M</span>
-            <span role="cell">~$32.28</span>
-          </div>
-          <div class="preview-row preview-total" role="row">
-            <span role="cell">combined</span>
-            <span role="cell">4 models</span>
-            <span role="cell">142.8M</span>
-            <span role="cell">~$86.40</span>
-          </div>
-        </div>
-
-        <div class="preview-foot">
-          <span><i aria-hidden="true"></i> 2 sources parsed</span>
-          <span>pricing partly estimated</span>
+          <pre class="terminal-body" aria-hidden="true"><span class="t-line t-cmd"><span class="t-prompt">❯ </span><span class="t-typed">llm-usage monthly --source codex,claude</span></span><span class="t-line t-dim" style="--d: 1.9s"><span class="t-cyan">ℹ</span> 1,354 session files · 105,232 events</span><span class="t-line t-dim" style="--d: 2.05s"><span class="t-cyan">ℹ</span> pricing loaded from cache</span><span class="t-line t-gap" style="--d: 2.15s"> </span><span class="t-line t-frame" style="--d: 2.25s">╭─────────┬────────┬────────┬─────────┬──────────╮</span><span class="t-line t-head" style="--d: 2.32s"><span class="t-frame">│</span> Period  <span class="t-frame">│</span> Source <span class="t-frame">│</span> Models <span class="t-frame">│</span>  Tokens <span class="t-frame">│</span>     Cost <span class="t-frame">│</span></span><span class="t-line t-frame" style="--d: 2.39s">├─────────┼────────┼────────┼─────────┼──────────┤</span><span class="t-line" style="--d: 2.46s"><span class="t-frame">│</span> 2026-01 <span class="t-frame">│</span> <span class="t-accent">codex</span>  <span class="t-frame">│</span> 2      <span class="t-frame">│</span>   91.4M <span class="t-frame">│</span>   $54.12 <span class="t-frame">│</span></span><span class="t-line" style="--d: 2.53s"><span class="t-frame">│</span> 2026-01 <span class="t-frame">│</span> <span class="t-accent">claude</span> <span class="t-frame">│</span> 2      <span class="t-frame">│</span>   51.4M <span class="t-frame">│</span>  <span class="t-yellow">~</span>$32.28 <span class="t-frame">│</span></span><span class="t-line t-frame" style="--d: 2.6s">├─────────┼────────┼────────┼─────────┼──────────┤</span><span class="t-line t-total" style="--d: 2.67s"><span class="t-frame">│</span> total   <span class="t-frame">│</span>        <span class="t-frame">│</span> 4      <span class="t-frame">│</span>  142.8M <span class="t-frame">│</span>  <span class="t-yellow">~</span>$86.40 <span class="t-frame">│</span></span><span class="t-line t-frame" style="--d: 2.74s">╰─────────┴────────┴────────┴─────────┴──────────╯</span><span class="t-line t-gap" style="--d: 2.8s"> </span><span class="t-line t-dim" style="--d: 2.9s"><span class="t-cyan">✔</span> 2 sources parsed · <span class="t-yellow">~</span> marks estimated pricing</span><span class="t-line" style="--d: 3.4s"><span class="t-prompt">❯ </span><span class="t-cursor"></span></span></pre>
+          <p class="sr-only">
+            Example: llm-usage monthly --source codex,claude reports 91.4M codex tokens for
+            $54.12 and 51.4M claude tokens for an estimated $32.28 — 142.8M tokens and an
+            estimated $86.40 combined. Estimates are marked with a tilde.
+          </p>
         </div>
       </div>
     </section>
 
-    <section class="fact-strip" aria-label="Product facts">
-      <div>
-        <strong>16</strong>
-        <span>source adapters</span>
-      </div>
-      <div>
-        <strong>Local</strong>
-        <span>session processing</span>
-      </div>
-      <div>
-        <strong>Offline</strong>
-        <span>pricing snapshot included</span>
-      </div>
-      <div>
-        <strong>4</strong>
-        <span>output families</span>
-      </div>
+    <section class="statusline" aria-label="Product facts">
+      <span class="statusline-cell"><strong>16</strong> source adapters</span>
+      <span class="statusline-cell"><strong>4</strong> output families</span>
+      <span class="statusline-cell"><strong>offline</strong> pricing snapshot</span>
+      <span class="statusline-cell"><strong>0</strong> session uploads</span>
+      <span class="statusline-spark" aria-hidden="true">▁▂▄▃▆▂▇▅ tokens/day</span>
     </section>
 
-    <section class="reports section" aria-labelledby="reports-title">
+    <div class="source-ticker" aria-label="Supported tools">
+      <span class="source-ticker-label">reads your local history from</span>
+      <div class="source-ticker-track">
+        <div class="source-ticker-set">
+          {doctorSources.map((source) => <span>{source.name}</span>)}
+        </div>
+        <div class="source-ticker-set" aria-hidden="true">
+          {doctorSources.map((source) => <span>{source.name}</span>)}
+        </div>
+      </div>
+    </div>
+
+    <section id="reports" class="reports section" aria-labelledby="reports-title">
       <div class="section-heading">
-        <p class="eyebrow">Choose the question first</p>
-        <h2 id="reports-title">A report for the work you want to understand.</h2>
+        <p class="eyebrow"># 01 · reports</p>
+        <h2 id="reports-title">Ask the question first. There’s a table for it.</h2>
         <p>
           Start with a calendar rollup, then move to sessions, repositories, or candidate
           pricing when you need a narrower answer.
@@ -206,12 +250,21 @@ const sourceGroups = [
       <div class="report-list">
         {reportGroups.map((report) => (
           <article class="report-row">
-            <span class="report-number font-mono">{report.number}</span>
-            <h3>{report.question}</h3>
-            <p>{report.answer}</p>
-            <div class="command-list">
-              {report.commands.map((command) => <code>llm-usage {command}</code>)}
+            <div class="report-identity">
+              <span class="report-number font-mono">{report.number}</span>
+              <span class="report-label">{report.label}</span>
             </div>
+            <div class="report-copy">
+              <h3>{report.question}</h3>
+              <p>{report.answer}</p>
+            </div>
+            <div class="command-list">
+              <span class="command-label">Try it</span>
+              {report.commands.map((command) => (
+                <code><span aria-hidden="true">$</span> llm-usage {command}</code>
+              ))}
+            </div>
+            <span class="report-arrow" aria-hidden="true">&#8599;</span>
           </article>
         ))}
       </div>
@@ -219,95 +272,110 @@ const sourceGroups = [
       <a class="text-link" href={link('cli-reference/')}>Browse every command and option</a>
     </section>
 
-    <section class="sources section" aria-labelledby="sources-title">
-      <div class="sources-copy">
-        <p class="eyebrow">Different files, one event model</p>
-        <h2 id="sources-title">Sixteen sources without sixteen reporting workflows.</h2>
+    <section class="pipeline section" aria-labelledby="pipeline-title">
+      <div class="section-heading">
+        <p class="eyebrow"># 02 · pipeline</p>
+        <h2 id="pipeline-title">Four stages. One pipe.</h2>
         <p>
-          Each adapter discovers its tool's local data and converts it into the same usage
-          event shape. Filters, pricing, aggregation, and exports work the same way after that
-          boundary.
+          The useful engineering sits between the files and the table. Every report runs the
+          same pipeline, so sixteen different log formats behave like one dataset.
+        </p>
+      </div>
+
+      <div class="pipe-line font-mono" aria-hidden="true">
+        {pipelineStages.map((stage, index) => (
+          <>
+            {index > 0 && <span class="pipe-char">|</span>}
+            <span class="pipe-word">{stage.name}</span>
+          </>
+        ))}
+      </div>
+
+      <ol class="pipe-stages">
+        {pipelineStages.map((stage, index) => (
+          <li>
+            <span class="flow-index font-mono">0{index + 1}</span>
+            <strong>{stage.name}</strong>
+            <p>{stage.detail}</p>
+          </li>
+        ))}
+      </ol>
+
+      <div class="pipeline-notes">
+        <article>
+          <span class="note-label label">Persistent ledger</span>
+          <h3>Unchanged files do not need another parse.</h3>
+          <p>
+            A local SQLite event store keeps normalized events and parse diagnostics. It also
+            powers optional history for session files that have left the disk.
+          </p>
+          <a href={link('architecture/event-store/')}>How the event store works</a>
+        </article>
+        <article>
+          <span class="note-label label">Honest pricing</span>
+          <h3>Unknown cost stays unknown.</h3>
+          <p>
+            Reports mark partial estimates with <code>~</code> and unresolved rows with
+            <code>-</code>. The cost engine does not invent a rate for a token bucket it cannot
+            price.
+          </p>
+          <a href={link('pricing/')}>Read the pricing rules</a>
+        </article>
+      </div>
+    </section>
+
+    <section id="sources" class="sources section" aria-labelledby="sources-title">
+      <div class="sources-copy">
+        <p class="eyebrow"># 03 · sources</p>
+        <h2 id="sources-title">Sixteen adapters. One event shape.</h2>
+        <p>
+          Each adapter discovers its tool’s local data — JSONL, JSON, or SQLite — and converts
+          it into the same usage event. Filters, pricing, aggregation, and exports work
+          identically after that boundary.
         </p>
         <a class="text-link" href={link('sources/')}>See discovery paths and overrides</a>
       </div>
 
-      <div class="source-groups">
-        {sourceGroups.map((group) => (
-          <div class="source-group">
-            <span class="source-format label">{group.format}</span>
-            <ul>
-              {group.sources.map((source) => <li>{source}</li>)}
-            </ul>
-          </div>
-        ))}
+      <div class="doctor-panel" role="list" aria-label="Supported sources">
+        <div class="doctor-command font-mono" aria-hidden="true">
+          <span class="t-prompt">❯ </span>llm-usage doctor
+        </div>
+        <ul class="doctor-grid">
+          {doctorSources.map((source) => (
+            <li role="listitem">
+              <span class="doctor-check" aria-hidden="true">✔</span>
+              <span class="doctor-name">{source.name}</span>
+              <span class={`doctor-format doctor-format-${source.format}`}>{source.format}</span>
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
 
-    <section class="pipeline section" aria-labelledby="pipeline-title">
-      <div class="section-heading pipeline-heading">
-        <p class="eyebrow">Designed for repeatable reports</p>
-        <h2 id="pipeline-title">The useful engineering sits between the files and the table.</h2>
+    <section class="wrapped section" aria-labelledby="wrapped-title">
+      <div class="section-heading">
+        <p class="eyebrow"># 04 · wrapped</p>
+        <h2 id="wrapped-title">A year of sessions fits in one artifact.</h2>
+        <p>
+          <code>llm-usage wrapped</code> recaps active days, streaks, models, sources, tokens,
+          and estimated cost — in the terminal, or as an SVG you can share.
+        </p>
       </div>
 
-      <div class="pipeline-layout">
-        <ol class="pipeline-flow">
-          <li>
-            <span class="flow-index font-mono">01</span>
-            <div>
-              <strong>Discover</strong>
-              <p>Find default source locations or apply the paths in your TOML config.</p>
-            </div>
-          </li>
-          <li>
-            <span class="flow-index font-mono">02</span>
-            <div>
-              <strong>Normalize</strong>
-              <p>Convert source-specific records into deterministic usage events.</p>
-            </div>
-          </li>
-          <li>
-            <span class="flow-index font-mono">03</span>
-            <div>
-              <strong>Price</strong>
-              <p>Keep explicit cost or estimate it from cached LiteLLM data.</p>
-            </div>
-          </li>
-          <li>
-            <span class="flow-index font-mono">04</span>
-            <div>
-              <strong>Report</strong>
-              <p>Aggregate once, then render terminal, JSON, Markdown, or SVG output.</p>
-            </div>
-          </li>
-        </ol>
-
-        <div class="pipeline-notes">
-          <article>
-            <span class="note-label label">Persistent ledger</span>
-            <h3>Unchanged files do not need another parse.</h3>
-            <p>
-              A local SQLite event store keeps normalized events and parse diagnostics. It also
-              powers optional history for session files that have left the disk.
-            </p>
-            <a href={link('architecture/event-store/')}>How the event store works</a>
-          </article>
-          <article>
-            <span class="note-label label">Honest pricing</span>
-            <h3>Unknown cost stays unknown.</h3>
-            <p>
-              Reports mark partial estimates with <code>~</code> and unresolved rows with
-              <code>-</code>. The cost engine does not invent a rate for a token bucket it cannot
-              price.
-            </p>
-            <a href={link('pricing/')}>Read the pricing rules</a>
-          </article>
+      <figure class="heatmap-figure">
+        <div class="heatmap" aria-hidden="true">
+          {heatCells.map((level) => <i class={`heat-${level}`}></i>)}
         </div>
-      </div>
+        <figcaption>
+          <span class="font-mono">llm-usage wrapped --share</span>
+          <span>illustrative activity — your recap uses your own sessions</span>
+        </figcaption>
+      </figure>
     </section>
 
     <section class="benchmark section" aria-labelledby="benchmark-title">
       <div class="benchmark-copy">
-        <p class="eyebrow">Published with the slower runs included</p>
+        <p class="eyebrow"># 05 · benchmarks</p>
         <h2 id="benchmark-title">Performance numbers you can audit.</h2>
         <p>
           The benchmark records five-run medians on real local corpora and publishes the machine,
@@ -337,10 +405,18 @@ const sourceGroups = [
     </section>
 
     <section class="final-cta section" aria-labelledby="cta-title">
-      <div>
-        <p class="eyebrow">One command is enough to start</p>
-        <h2 id="cta-title">Run the report against the sessions already on your machine.</h2>
-      </div>
+      <p class="eyebrow"># 06 · start</p>
+      <h2 id="cta-title">The sessions are already on your disk. Ask them something.</h2>
+      <button
+        class="install-command install-command-large"
+        type="button"
+        aria-label="Copy the npm install command"
+        data-install-command
+      >
+        <span class="prompt" aria-hidden="true">$</span>
+        <code>npm install -g llm-usage-metrics</code>
+        <span class="copy-label" data-copy-label>Copy</span>
+      </button>
       <div class="cta-actions">
         <a class="button button-primary" href={link('getting-started/')}>Open the setup guide</a>
         <a class="button button-secondary" href={npmUrl} target="_blank" rel="noopener noreferrer"
@@ -368,24 +444,25 @@ const sourceGroups = [
   </footer>
 
   <script is:inline>
-    const installButton = document.querySelector('[data-install-command]');
-    const copyLabel = document.querySelector('[data-copy-label]');
-    const copyStatus = document.querySelector('[data-copy-status]');
+    for (const button of document.querySelectorAll('[data-install-command]')) {
+      const copyLabel = button.querySelector('[data-copy-label]');
+      const copyStatus = document.querySelector('[data-copy-status]');
 
-    installButton?.addEventListener('click', async () => {
-      try {
-        await navigator.clipboard.writeText('npm install -g llm-usage-metrics');
-        if (copyLabel) copyLabel.textContent = 'Copied';
-        if (copyStatus) copyStatus.textContent = 'Install command copied.';
-      } catch {
-        if (copyLabel) copyLabel.textContent = 'Copy failed';
-        if (copyStatus) copyStatus.textContent = 'The install command could not be copied.';
-      }
+      button.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText('npm install -g llm-usage-metrics');
+          if (copyLabel) copyLabel.textContent = 'Copied';
+          if (copyStatus) copyStatus.textContent = 'Install command copied.';
+        } catch {
+          if (copyLabel) copyLabel.textContent = 'Copy failed';
+          if (copyStatus) copyStatus.textContent = 'The install command could not be copied.';
+        }
 
-      window.setTimeout(() => {
-        if (copyLabel) copyLabel.textContent = 'Copy';
-      }, 2000);
-    });
+        window.setTimeout(() => {
+          if (copyLabel) copyLabel.textContent = 'Copy';
+        }, 2000);
+      });
+    }
   </script>
 </StarlightPage>
 
@@ -417,16 +494,89 @@ const sourceGroups = [
     padding-inline: clamp(1.25rem, 4vw, 3rem);
   }
 
+  .page-nav {
+    position: sticky;
+    top: calc(var(--sl-nav-height) + 0.75rem);
+    z-index: var(--z-sticky);
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    width: min(100%, 56rem);
+    min-height: 3.25rem;
+    margin: 0.75rem auto -4rem;
+    padding: 0.35rem 0.4rem 0.35rem 1rem;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-full);
+    background: color-mix(in srgb, var(--color-bg) 78%, transparent);
+    box-shadow:
+      inset 0 1px 0 var(--border-default),
+      0 12px 36px var(--shadow-color);
+    backdrop-filter: blur(18px);
+  }
+
+  .page-nav a {
+    text-decoration: none;
+  }
+
+  .page-nav-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--color-text);
+    font-family: var(--font-mono);
+    font-size: 0.76rem;
+    font-weight: 600;
+  }
+
+  .brand-prompt {
+    color: var(--color-accent);
+  }
+
+  .page-nav-links {
+    display: flex;
+    gap: 1.5rem;
+  }
+
+  .page-nav-links a {
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+    font-weight: 500;
+    transition: color var(--transition-fast);
+  }
+
+  .page-nav-links a:hover {
+    color: var(--color-text);
+  }
+
+  .page-nav-cta {
+    justify-self: end;
+    padding: 0.65rem 0.9rem;
+    border-radius: var(--radius-full);
+    background: var(--color-accent);
+    color: var(--color-accent-ink);
+    font-size: 0.72rem;
+    font-weight: 700;
+    transition:
+      background var(--transition-fast),
+      transform var(--transition-fast);
+  }
+
+  .page-nav-cta:hover {
+    background: var(--color-accent-hover);
+  }
+
+  .page-nav-cta:active {
+    transform: scale(0.98);
+  }
+
   .page-grid {
     position: fixed;
     inset: 0;
     z-index: -1;
     pointer-events: none;
-    background-image:
-      linear-gradient(to right, var(--border-subtle) 1px, transparent 1px),
-      linear-gradient(to bottom, var(--border-subtle) 1px, transparent 1px);
-    background-size: 4rem 4rem;
-    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), transparent 48rem);
+    background-image: radial-gradient(var(--border-strong) 1px, transparent 1px);
+    background-size: 2rem 2rem;
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 44rem);
   }
 
   .section {
@@ -460,17 +610,19 @@ const sourceGroups = [
   }
 
   h2 {
-    max-width: 18ch;
+    max-width: 20ch;
     margin-bottom: 1.25rem;
-    font-size: clamp(2rem, 4vw, 3.5rem);
+    font-size: clamp(2rem, 4vw, 3.25rem);
     font-weight: 600;
-    line-height: 1.02;
+    line-height: 1.04;
   }
+
+  /* ---------- hero ---------- */
 
   .hero {
     display: grid;
-    grid-template-columns: minmax(0, 0.9fr) minmax(32rem, 1.1fr);
-    gap: clamp(3rem, 7vw, 7rem);
+    grid-template-columns: minmax(0, 1fr) minmax(30rem, 1fr);
+    gap: clamp(3rem, 6vw, 6rem);
     align-items: center;
     min-height: calc(100dvh - var(--sl-nav-height));
     padding-block: clamp(4rem, 10vw, 8rem);
@@ -498,26 +650,56 @@ const sourceGroups = [
     height: 0.45rem;
     border-radius: 50%;
     background: var(--color-accent);
+    animation: pulse 2.4s ease-in-out infinite;
   }
 
   .hero .eyebrow {
     margin-bottom: 1.15rem;
+    text-transform: none;
+    letter-spacing: 0.02em;
   }
 
   .hero h1 {
-    max-width: 11ch;
+    max-width: 13ch;
     margin-bottom: 1.5rem;
-    font-size: clamp(3rem, 6vw, 5.4rem);
+    font-size: clamp(2.9rem, 5.6vw, 5rem);
     font-weight: 600;
-    line-height: 0.96;
+    line-height: 0.98;
+  }
+
+  .hero h1 span {
+    position: relative;
+    color: var(--color-accent);
+  }
+
+  .hero h1 span::after {
+    position: absolute;
+    right: 0.03em;
+    bottom: -0.08em;
+    left: 0;
+    height: 0.08em;
+    border-radius: var(--radius-full);
+    background: currentColor;
+    content: '';
+    opacity: 0.45;
+    transform: scaleX(0);
+    transform-origin: left;
+    animation: draw-line 700ms 700ms var(--ease-out) forwards;
   }
 
   .hero-summary {
-    max-width: 58ch;
+    max-width: 56ch;
     margin-bottom: 2rem;
     color: var(--color-text-muted);
-    font-size: clamp(1.05rem, 1.5vw, 1.2rem);
+    font-size: clamp(1.05rem, 1.5vw, 1.18rem);
     line-height: 1.65;
+  }
+
+  .hero-summary strong {
+    color: var(--color-text);
+    font-family: var(--font-mono);
+    font-size: 0.92em;
+    font-weight: 600;
   }
 
   .hero-actions,
@@ -617,175 +799,311 @@ const sourceGroups = [
     text-transform: uppercase;
   }
 
-  .report-preview {
+  /* ---------- terminal ---------- */
+
+  .terminal-stage {
     position: relative;
-    overflow: hidden;
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-lg);
-    background: var(--color-bg-code);
-    box-shadow: 0 24px 60px -36px var(--shadow-elevated);
-    animation: enter 700ms 120ms var(--ease-out) both;
+    perspective: 1000px;
   }
 
-  .report-preview::before {
+  .terminal-glow {
     position: absolute;
-    inset: 0 auto 0 0;
-    width: 3px;
-    background: var(--color-accent);
-    content: '';
+    inset: -12% -8%;
+    z-index: -1;
+    background: radial-gradient(
+      ellipse at 60% 40%,
+      color-mix(in srgb, var(--color-accent) 22%, transparent),
+      transparent 65%
+    );
+    filter: blur(48px);
   }
 
-  .preview-header,
-  .preview-foot {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+  .terminal {
+    /* A terminal is dark in both site themes. */
+    --term-bg: #0d0f0c;
+    --term-bar: #12140f;
+    --term-text: #e9e8df;
+    --term-dim: #83887b;
+    --term-frame: #4a4e44;
+    --term-border: rgba(241, 240, 233, 0.14);
+    --term-accent: #ef9067;
+    --term-cyan: #7cc3cd;
+    --term-yellow: #e0bc7c;
+    overflow: hidden;
+    border: 1px solid var(--term-border);
+    border-radius: var(--radius-lg);
+    background: var(--term-bg);
+    box-shadow: 0 32px 80px -40px var(--shadow-elevated);
+    animation: terminal-enter 800ms 120ms var(--ease-out) both;
+    transform-origin: center left;
   }
 
-  .preview-header {
-    padding: 1.25rem 1.4rem;
-    border-bottom: 1px solid var(--border-default);
-  }
-
-  .preview-header > div {
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-  }
-
-  .preview-kicker {
-    color: var(--color-text-dim);
-    font-size: 0.62rem;
-  }
-
-  .preview-title {
-    color: var(--color-text);
-    font-size: 0.9rem;
-    font-weight: 600;
-  }
-
-  .preview-status {
-    padding: 0.3rem 0.5rem;
-    border: 1px solid color-mix(in srgb, var(--color-accent) 35%, transparent);
-    border-radius: var(--radius-sm);
-    color: var(--color-accent);
-    font-size: 0.6rem;
-  }
-
-  .preview-command {
-    padding: 1.25rem 1.4rem 1rem;
-    color: var(--color-text-muted);
-    font-size: 0.75rem;
-  }
-
-  .preview-command span {
-    color: var(--color-accent);
-  }
-
-  .preview-table {
-    padding-inline: 1.4rem;
-    font-family: var(--font-mono);
-    font-size: clamp(0.66rem, 1.15vw, 0.78rem);
-  }
-
-  .preview-row {
+  .floating-stat {
+    position: absolute;
+    z-index: 2;
     display: grid;
-    grid-template-columns: 1fr 1fr 0.9fr 0.75fr;
-    gap: 0.75rem;
-    align-items: center;
-    min-height: 3.25rem;
-    border-top: 1px solid var(--border-default);
-    color: var(--color-text-muted);
+    min-width: 9.5rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--color-bg-elevated) 88%, transparent);
+    box-shadow:
+      inset 0 1px 0 var(--border-default),
+      0 18px 35px var(--shadow-color);
+    backdrop-filter: blur(14px);
+    font-family: var(--font-mono);
+    animation: float 5s ease-in-out infinite;
   }
 
-  .preview-row span:nth-child(n + 3) {
-    text-align: right;
+  .floating-stat-top {
+    top: -2.4rem;
+    right: -1.5rem;
   }
 
-  .preview-table-head {
-    min-height: 2.2rem;
-    border-top: 0;
+  .floating-stat-bottom {
+    right: 1.25rem;
+    bottom: -2.25rem;
+    grid-template-columns: auto 1fr;
+    column-gap: 0.55rem;
+    animation-delay: -2.2s;
+  }
+
+  .floating-stat > span:not(.live-dot),
+  .floating-stat small {
     color: var(--color-text-dim);
-    font-family: var(--font-sans);
-    font-size: 0.62rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
+    font-size: 0.58rem;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
   }
 
-  .preview-row .source-name {
-    color: var(--color-accent);
+  .floating-stat strong {
+    color: var(--color-text);
+    font-size: 1.05rem;
   }
 
-  .preview-total {
-    color: var(--color-text);
+  .floating-stat-bottom small {
+    grid-column: 2;
+  }
+
+  .live-dot {
+    grid-row: 1 / span 2;
+    align-self: center;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: var(--color-accent);
+    box-shadow: 0 0 0 4px var(--color-accent-subtle);
+  }
+
+  .terminal-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    padding: 0.8rem 1.1rem;
+    border-bottom: 1px solid var(--term-border);
+    background: var(--term-bar);
+  }
+
+  .terminal-dots {
+    display: inline-flex;
+    gap: 0.4rem;
+  }
+
+  .terminal-dots i {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    background: var(--term-frame);
+  }
+
+  .terminal-title {
+    color: var(--term-dim);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+  }
+
+  .terminal-badge {
+    margin-left: auto;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid color-mix(in srgb, var(--term-accent) 40%, transparent);
+    border-radius: var(--radius-sm);
+    color: var(--term-accent);
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .terminal-body {
+    margin: 0;
+    padding: 1.2rem 1.3rem 1.35rem;
+    overflow-x: auto;
+    background: transparent;
+    color: var(--term-text);
+    font-family: var(--font-mono);
+    font-size: clamp(0.62rem, 1.05vw, 0.78rem);
+    line-height: 1.6;
+  }
+
+  .t-line {
+    display: block;
+    white-space: pre;
+  }
+
+  .t-line[style] {
+    animation: t-print 0.25s var(--ease-out) var(--d) backwards;
+  }
+
+  .t-cmd {
+    margin-bottom: 0.35rem;
+  }
+
+  .t-typed {
+    display: inline-block;
+    overflow: hidden;
+    width: 39ch;
+    vertical-align: bottom;
+    white-space: nowrap;
+    animation: t-type 1.5s steps(39) 0.4s both;
+  }
+
+  .t-prompt {
+    color: var(--term-accent);
+  }
+
+  .t-dim {
+    color: var(--term-dim);
+  }
+
+  .t-frame {
+    color: var(--term-frame);
+  }
+
+  .t-head {
+    color: var(--term-dim);
+  }
+
+  .t-total {
+    color: var(--term-text);
     font-weight: 600;
   }
 
-  .preview-foot {
-    padding: 1rem 1.4rem;
-    border-top: 1px solid var(--border-default);
-    color: var(--color-text-dim);
-    font-size: 0.65rem;
+  .t-accent {
+    color: var(--term-accent);
   }
 
-  .preview-foot span:first-child {
+  .t-cyan {
+    color: var(--term-cyan);
+  }
+
+  .t-yellow {
+    color: var(--term-yellow);
+  }
+
+  .t-gap {
+    line-height: 0.9;
+  }
+
+  .t-cursor {
+    display: inline-block;
+    width: 0.55em;
+    height: 1.15em;
+    vertical-align: text-bottom;
+    background: var(--term-accent);
+    animation: t-blink 1.1s steps(1) infinite;
+  }
+
+  /* ---------- statusline ---------- */
+
+  .statusline {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    gap: 0.45rem;
-  }
-
-  .preview-foot i {
-    width: 0.4rem;
-    height: 0.4rem;
-    border-radius: 50%;
-    background: var(--color-accent);
-  }
-
-  .fact-strip {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    gap: 0.5rem 0;
+    padding-block: 0.9rem;
     border-block: 1px solid var(--border-default);
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
   }
 
-  .fact-strip > div {
-    display: flex;
-    min-height: 7rem;
-    flex-direction: column;
-    justify-content: center;
-    padding: 1.25rem;
+  .statusline-cell {
+    padding-inline: 1.25rem;
     border-right: 1px solid var(--border-default);
   }
 
-  .fact-strip > div:first-child {
+  .statusline-cell:first-child {
     padding-left: 0;
   }
 
-  .fact-strip > div:last-child {
-    border-right: 0;
-  }
-
-  .fact-strip strong {
-    color: var(--color-text);
-    font-family: var(--font-mono);
-    font-size: 1.3rem;
+  .statusline-cell strong {
+    color: var(--color-accent);
     font-weight: 600;
   }
 
-  .fact-strip span {
+  .statusline-spark {
+    margin-left: auto;
+    padding-left: 1.25rem;
     color: var(--color-text-dim);
-    font-size: 0.78rem;
+    letter-spacing: 0.05em;
   }
+
+  .source-ticker {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 1.5rem;
+    padding-block: 1rem;
+    overflow: hidden;
+    border-bottom: 1px solid var(--border-default);
+  }
+
+  .source-ticker-label {
+    color: var(--color-text-dim);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .source-ticker-track {
+    display: flex;
+    width: max-content;
+    min-width: 100%;
+    overflow: hidden;
+    mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+  }
+
+  .source-ticker-set {
+    display: flex;
+    flex-shrink: 0;
+    gap: 2rem;
+    min-width: max-content;
+    padding-right: 2rem;
+    animation: ticker 36s linear infinite;
+  }
+
+  .source-ticker-set span {
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  /* ---------- section headings ---------- */
 
   .section-heading {
     display: grid;
-    grid-template-columns: minmax(14rem, 0.7fr) minmax(20rem, 1.3fr);
+    grid-template-columns: minmax(12rem, 0.6fr) minmax(20rem, 1.4fr);
     column-gap: 4rem;
-    margin-bottom: 4.5rem;
+    margin-bottom: 4rem;
   }
 
   .section-heading .eyebrow {
     grid-row: 1 / span 2;
+    text-transform: none;
+    letter-spacing: 0.04em;
   }
 
   .section-heading h2,
@@ -803,33 +1121,119 @@ const sourceGroups = [
     line-height: 1.65;
   }
 
+  /* ---------- reports ---------- */
+
   .report-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     border-top: 1px solid var(--border-strong);
+    border-left: 1px solid var(--border-default);
+    counter-reset: report;
   }
 
   .report-row {
+    position: relative;
     display: grid;
-    grid-template-columns: 3rem minmax(12rem, 0.8fr) minmax(18rem, 1.2fr) minmax(12rem, auto);
-    gap: 1.5rem;
-    align-items: start;
-    padding-block: 1.75rem;
+    grid-template-rows: auto 1fr auto;
+    min-height: 22rem;
+    padding: clamp(1.5rem, 3vw, 2.25rem);
+    overflow: hidden;
+    border-right: 1px solid var(--border-default);
     border-bottom: 1px solid var(--border-default);
+    background: color-mix(in srgb, var(--color-bg-card) 34%, transparent);
+    transition:
+      background var(--transition-base),
+      transform var(--transition-base);
+  }
+
+  .report-row::before {
+    position: absolute;
+    right: -3rem;
+    bottom: -4rem;
+    width: 11rem;
+    height: 11rem;
+    border: 1px solid var(--border-default);
+    border-radius: 50%;
+    content: '';
+    opacity: 0;
+    transform: scale(0.75);
+    transition:
+      opacity var(--transition-base),
+      transform var(--transition-slow);
+  }
+
+  .report-row:hover {
+    z-index: 1;
+    background: var(--color-bg-elevated);
+    transform: translateY(-0.25rem);
+  }
+
+  .report-row:hover::before {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .report-row:first-child {
+    grid-row: span 2;
+    min-height: 44rem;
+    background: var(--color-bg-code);
+  }
+
+  .report-row:first-child .report-copy {
+    align-self: center;
+  }
+
+  .report-row:first-child h3 {
+    max-width: 8ch;
+    font-size: clamp(2.4rem, 5vw, 4.5rem);
+  }
+
+  .report-identity {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
   }
 
   .report-number {
-    padding-top: 0.2rem;
+    display: inline-grid;
+    width: 2rem;
+    height: 2rem;
+    place-items: center;
+    border: 1px solid var(--border-default);
+    border-radius: 50%;
+    color: var(--color-text-muted);
+    font-size: 0.64rem;
+    transition: color var(--transition-fast);
+  }
+
+  .report-row:hover .report-number {
     color: var(--color-accent);
-    font-size: 0.72rem;
   }
 
-  .report-row h3 {
-    margin: 0;
-    font-size: 1.1rem;
+  .report-label,
+  .command-label {
+    color: var(--color-text-dim);
+    font-family: var(--font-mono);
+    font-size: 0.63rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .report-copy {
+    align-self: end;
+    padding-block: 2.5rem;
+  }
+
+  .report-copy h3 {
+    max-width: 15ch;
+    margin: 0 0 1rem;
+    font-size: clamp(1.6rem, 3vw, 2.35rem);
     font-weight: 600;
-    line-height: 1.3;
+    line-height: 1.05;
   }
 
-  .report-row > p {
+  .report-copy > p {
+    max-width: 52ch;
     margin: 0;
     color: var(--color-text-muted);
     font-size: 0.9rem;
@@ -839,18 +1243,44 @@ const sourceGroups = [
   .command-list {
     display: flex;
     flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 0.4rem;
+    align-items: center;
+    gap: 0.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-default);
   }
 
   .command-list code {
-    padding: 0.35rem 0.5rem;
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-sm);
-    background: var(--color-bg-code);
+    padding: 0.42rem 0.6rem;
+    border: 0;
+    border-radius: var(--radius-full);
+    background: var(--color-bg);
     color: var(--color-text-secondary);
-    font-size: 0.68rem;
+    font-size: 0.64rem;
     white-space: nowrap;
+  }
+
+  .command-list code span {
+    color: var(--color-accent);
+  }
+
+  .report-arrow {
+    position: absolute;
+    top: 1.9rem;
+    right: 2rem;
+    color: var(--color-text-dim);
+    font-size: 1rem;
+    opacity: 0;
+    transform: translate(-0.35rem, 0.35rem);
+    transition:
+      color var(--transition-fast),
+      opacity var(--transition-fast),
+      transform var(--transition-fast);
+  }
+
+  .report-row:hover .report-arrow {
+    color: var(--color-accent);
+    opacity: 1;
+    transform: translate(0, 0);
   }
 
   .text-link {
@@ -866,117 +1296,54 @@ const sourceGroups = [
     color: var(--color-accent);
   }
 
-  .sources {
+  /* ---------- pipeline ---------- */
+
+  .pipe-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.4em;
+    margin-bottom: 3.5rem;
+    color: var(--color-text);
+    font-size: clamp(1.4rem, 4.2vw, 3rem);
+    font-weight: 600;
+    letter-spacing: var(--tracking-tight);
+  }
+
+  .pipe-char {
+    color: var(--color-accent);
+    font-weight: 400;
+  }
+
+  .pipe-stages {
     display: grid;
-    grid-template-columns: minmax(20rem, 0.85fr) minmax(30rem, 1.15fr);
-    gap: clamp(4rem, 10vw, 9rem);
-    align-items: start;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 2rem;
+    margin: 0 0 4rem;
+    padding: 0;
+    list-style: none;
   }
 
-  .sources-copy {
-    position: sticky;
-    top: calc(var(--sl-nav-height) + 3rem);
-  }
-
-  .sources-copy .eyebrow,
-  .benchmark-copy .eyebrow {
-    margin-bottom: 1rem;
-  }
-
-  .sources-copy .text-link,
-  .benchmark-copy .text-link {
-    margin-top: 1.75rem;
-  }
-
-  .source-groups {
+  .pipe-stages li {
+    padding-top: 1.25rem;
     border-top: 1px solid var(--border-strong);
   }
 
-  .source-group {
-    display: grid;
-    grid-template-columns: 5rem 1fr;
-    gap: 2rem;
-    padding-block: 2rem;
-    border-bottom: 1px solid var(--border-default);
-  }
-
-  .source-format {
-    padding-top: 0.25rem;
-    color: var(--color-accent);
-  }
-
-  .source-group ul {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.65rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  .source-group li {
-    padding: 0.45rem 0.65rem;
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-sm);
-    background: var(--color-bg-card);
-    color: var(--color-text-secondary);
-    font-size: 0.8rem;
-  }
-
-  .pipeline-heading {
-    margin-bottom: 4rem;
-  }
-
-  .pipeline-layout {
-    display: grid;
-    grid-template-columns: minmax(20rem, 0.85fr) minmax(24rem, 1.15fr);
-    gap: clamp(3rem, 8vw, 7rem);
-  }
-
-  .pipeline-flow {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  .pipeline-flow li {
-    position: relative;
-    display: grid;
-    grid-template-columns: 3rem 1fr;
-    gap: 1rem;
-    padding-bottom: 2rem;
-  }
-
-  .pipeline-flow li:not(:last-child)::before {
-    position: absolute;
-    top: 1.7rem;
-    bottom: 0.35rem;
-    left: 1rem;
-    width: 1px;
-    background: var(--border-strong);
-    content: '';
-  }
-
   .flow-index {
-    position: relative;
-    display: grid;
-    width: 2rem;
-    height: 2rem;
-    place-items: center;
-    border: 1px solid var(--border-strong);
-    border-radius: 50%;
-    background: var(--color-bg);
+    display: block;
+    margin-bottom: 0.9rem;
     color: var(--color-accent);
-    font-size: 0.62rem;
+    font-size: 0.68rem;
   }
 
-  .pipeline-flow strong {
+  .pipe-stages strong {
     color: var(--color-text);
-    font-size: 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
   }
 
-  .pipeline-flow p {
-    margin: 0.35rem 0 0;
+  .pipe-stages p {
+    margin: 0.5rem 0 0;
     color: var(--color-text-muted);
     font-size: 0.88rem;
     line-height: 1.55;
@@ -984,6 +1351,7 @@ const sourceGroups = [
 
   .pipeline-notes {
     display: grid;
+    grid-template-columns: repeat(2, 1fr);
     gap: 1px;
     overflow: hidden;
     border: 1px solid var(--border-default);
@@ -1003,9 +1371,9 @@ const sourceGroups = [
   .pipeline-notes h3 {
     max-width: 22ch;
     margin: 1rem 0;
-    font-size: clamp(1.5rem, 3vw, 2.25rem);
+    font-size: clamp(1.4rem, 2.4vw, 1.9rem);
     font-weight: 600;
-    line-height: 1.05;
+    line-height: 1.1;
   }
 
   .pipeline-notes p {
@@ -1021,6 +1389,157 @@ const sourceGroups = [
     font-weight: 600;
     text-underline-offset: 0.25rem;
   }
+
+  /* ---------- sources / doctor ---------- */
+
+  .sources {
+    display: grid;
+    grid-template-columns: minmax(20rem, 0.9fr) minmax(28rem, 1.1fr);
+    gap: clamp(4rem, 8vw, 8rem);
+    align-items: start;
+  }
+
+  .sources-copy .eyebrow,
+  .benchmark-copy .eyebrow {
+    margin-bottom: 1rem;
+    text-transform: none;
+    letter-spacing: 0.04em;
+  }
+
+  .sources-copy .text-link,
+  .benchmark-copy .text-link {
+    margin-top: 1.75rem;
+  }
+
+  .doctor-panel {
+    overflow: hidden;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg);
+    background: var(--color-bg-code);
+  }
+
+  .doctor-command {
+    padding: 1.1rem 1.4rem;
+    border-bottom: 1px solid var(--border-default);
+    color: var(--color-text-secondary);
+    font-size: 0.78rem;
+  }
+
+  .doctor-command .t-prompt {
+    color: var(--color-accent);
+  }
+
+  .doctor-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    margin: 0;
+    padding: 0.75rem 0;
+    list-style: none;
+  }
+
+  .doctor-grid li {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.5rem 1.4rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    transition: background var(--transition-fast);
+  }
+
+  .doctor-grid li:hover {
+    background: var(--color-bg-elevated);
+  }
+
+  .doctor-check {
+    color: var(--color-accent);
+  }
+
+  .doctor-name {
+    color: var(--color-text-secondary);
+  }
+
+  .doctor-format {
+    margin-left: auto;
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .doctor-format-jsonl {
+    color: var(--color-accent);
+  }
+
+  .doctor-format-json {
+    color: var(--color-cyan);
+  }
+
+  .doctor-format-sqlite {
+    color: var(--color-yellow);
+  }
+
+  /* ---------- wrapped / heatmap ---------- */
+
+  .heatmap-figure {
+    margin: 0;
+  }
+
+  .heatmap {
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-rows: repeat(7, auto);
+    grid-auto-columns: minmax(0, 1fr);
+    gap: 3px;
+    padding: 1.25rem;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    background: var(--color-bg-card);
+  }
+
+  .heatmap i {
+    aspect-ratio: 1;
+    border-radius: 2px;
+    transition: transform var(--transition-fast);
+  }
+
+  .heatmap i:hover {
+    transform: scale(1.35);
+  }
+
+  .heat-0 {
+    background: var(--border-subtle);
+  }
+
+  .heat-1 {
+    background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  }
+
+  .heat-2 {
+    background: color-mix(in srgb, var(--color-accent) 45%, transparent);
+  }
+
+  .heat-3 {
+    background: color-mix(in srgb, var(--color-accent) 70%, transparent);
+  }
+
+  .heat-4 {
+    background: var(--color-accent);
+  }
+
+  .heatmap-figure figcaption {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 0.9rem;
+    color: var(--color-text-dim);
+    font-size: 0.72rem;
+  }
+
+  .heatmap-figure .font-mono {
+    color: var(--color-text-muted);
+  }
+
+  /* ---------- benchmark ---------- */
 
   .benchmark {
     display: grid;
@@ -1063,20 +1582,38 @@ const sourceGroups = [
     font-size: 0.72rem;
   }
 
+  /* ---------- final cta ---------- */
+
   .final-cta {
-    display: grid;
-    grid-template-columns: 1.4fr auto;
-    gap: 3rem;
-    align-items: end;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
   }
 
   .final-cta .eyebrow {
     margin-bottom: 1rem;
+    text-transform: none;
+    letter-spacing: 0.04em;
   }
 
   .final-cta h2 {
-    margin-bottom: 0;
+    max-width: 24ch;
+    margin-bottom: 2.25rem;
   }
+
+  .install-command-large {
+    width: min(100%, 30rem);
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    border-color: var(--border-strong);
+  }
+
+  .final-cta .cta-actions {
+    justify-content: center;
+  }
+
+  /* ---------- footer ---------- */
 
   .landing-footer {
     display: grid;
@@ -1131,6 +1668,8 @@ const sourceGroups = [
     clip-path: inset(50%);
   }
 
+  /* ---------- animation ---------- */
+
   @keyframes enter {
     from {
       opacity: 0;
@@ -1142,40 +1681,108 @@ const sourceGroups = [
     }
   }
 
+  @keyframes terminal-enter {
+    from {
+      opacity: 0;
+      transform: translateY(1.5rem) rotateY(-4deg) rotateX(2deg);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) rotateY(0) rotateX(0);
+    }
+  }
+
+  @keyframes draw-line {
+    to {
+      transform: scaleX(1);
+    }
+  }
+
+  @keyframes float {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-0.45rem);
+    }
+  }
+
+  @keyframes ticker {
+    to {
+      transform: translateX(-100%);
+    }
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-accent) 45%, transparent);
+    }
+    50% {
+      box-shadow: 0 0 0 5px transparent;
+    }
+  }
+
+  @keyframes t-print {
+    from {
+      opacity: 0;
+    }
+  }
+
+  @keyframes t-type {
+    from {
+      width: 0;
+    }
+    to {
+      width: 39ch;
+    }
+  }
+
+  @keyframes t-blink {
+    50% {
+      opacity: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .t-line[style],
+    .t-typed {
+      animation: none;
+      width: auto;
+    }
+  }
+
+  /* ---------- responsive ---------- */
+
   @media (max-width: 980px) {
     .hero,
     .sources,
-    .pipeline-layout,
     .benchmark {
       grid-template-columns: 1fr;
     }
 
     .hero {
       min-height: auto;
+      padding-top: 8rem;
     }
 
-    .hero h1 {
-      max-width: 13ch;
-    }
-
-    .report-preview {
+    .terminal-stage {
       max-width: 44rem;
     }
 
-    .sources-copy {
-      position: static;
+    .pipe-stages {
+      grid-template-columns: repeat(2, 1fr);
     }
 
-    .report-row {
-      grid-template-columns: 2.5rem minmax(12rem, 0.8fr) minmax(18rem, 1.2fr);
+    .pipeline-notes {
+      grid-template-columns: 1fr;
     }
 
-    .command-list {
-      grid-column: 2 / -1;
-      justify-content: flex-start;
+    .report-row:first-child {
+      min-height: 38rem;
     }
 
-    .pipeline-layout,
     .benchmark {
       gap: 3rem;
     }
@@ -1189,7 +1796,24 @@ const sourceGroups = [
 
     .hero {
       gap: 3rem;
-      padding-block: 3.5rem 4.5rem;
+      padding-block: 7rem 5rem;
+    }
+
+    .page-nav {
+      top: calc(var(--sl-nav-height) + 0.5rem);
+      grid-template-columns: 1fr auto;
+      width: calc(100% - 0.5rem);
+      margin-bottom: -5rem;
+    }
+
+    .page-nav-links {
+      display: none;
+    }
+
+    .page-nav-cta {
+      min-height: 2.5rem;
+      display: inline-flex;
+      align-items: center;
     }
 
     .release-link {
@@ -1197,12 +1821,13 @@ const sourceGroups = [
     }
 
     .hero h1 {
-      font-size: clamp(2.75rem, 14vw, 4rem);
+      font-size: clamp(2.5rem, 13vw, 3.6rem);
     }
 
     .hero-actions,
     .cta-actions {
       flex-direction: column;
+      width: 100%;
     }
 
     .hero-actions .button,
@@ -1210,34 +1835,31 @@ const sourceGroups = [
       width: 100%;
     }
 
-    .preview-row {
-      grid-template-columns: 1fr 0.8fr 0.8fr;
+    .statusline {
+      font-size: 0.68rem;
     }
 
-    .preview-row span:nth-child(2) {
+    .statusline-cell {
+      padding-inline: 0.75rem;
+    }
+
+    .statusline-spark {
       display: none;
     }
 
-    .fact-strip {
-      grid-template-columns: repeat(2, 1fr);
+    .source-ticker {
+      grid-template-columns: 1fr;
+      gap: 0.75rem;
     }
 
-    .fact-strip > div {
-      min-height: 6rem;
-      padding: 1rem;
-      border-bottom: 1px solid var(--border-default);
+    .floating-stat-top {
+      top: -1.5rem;
+      right: -0.5rem;
     }
 
-    .fact-strip > div:first-child {
-      padding-left: 1rem;
-    }
-
-    .fact-strip > div:nth-child(2) {
-      border-right: 0;
-    }
-
-    .fact-strip > div:nth-child(n + 3) {
-      border-bottom: 0;
+    .floating-stat-bottom {
+      right: 0.75rem;
+      bottom: -2rem;
     }
 
     .section-heading {
@@ -1249,26 +1871,65 @@ const sourceGroups = [
       margin-bottom: 1rem;
     }
 
-    .report-row {
-      grid-template-columns: 2rem 1fr;
-      gap: 0.75rem 1rem;
+    .report-list {
+      grid-template-columns: 1fr;
     }
 
-    .report-row > p,
-    .command-list {
-      grid-column: 2;
+    .report-row,
+    .report-row:first-child {
+      grid-row: auto;
+      min-height: 22rem;
+    }
+
+    .report-row:first-child .report-copy {
+      align-self: end;
+    }
+
+    .report-row:first-child h3 {
+      max-width: 12ch;
+      font-size: clamp(2rem, 10vw, 3rem);
+    }
+
+    .report-copy {
+      padding-block: 2rem;
+    }
+
+    .report-arrow {
+      display: none;
+    }
+
+    .pipe-stages {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
     }
 
     .sources {
       gap: 3rem;
     }
 
-    .source-group {
+    .doctor-grid {
       grid-template-columns: 1fr;
-      gap: 1rem;
     }
 
-    .final-cta,
+    .heatmap {
+      gap: 2px;
+      padding: 0.9rem;
+    }
+
+    .heatmap-figure figcaption {
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .final-cta {
+      align-items: flex-start;
+      text-align: left;
+    }
+
+    .final-cta .cta-actions {
+      justify-content: flex-start;
+    }
+
     .landing-footer {
       grid-template-columns: 1fr;
       align-items: start;
@@ -1277,6 +1938,22 @@ const sourceGroups = [
     .landing-footer nav,
     .landing-footer > p {
       grid-column: 1;
+    }
+  }
+
+  @media (max-width: 430px) {
+    .floating-stat {
+      display: none;
+    }
+
+    .terminal-body {
+      font-size: 0.58rem;
+    }
+
+    .statusline-cell {
+      width: 50%;
+      padding: 0.4rem 0;
+      border-right: 0;
     }
   }
 </style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,12 +1,18 @@
 ---
-import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import '../styles/tokens.css';
 
-const rootPackage = JSON.parse(
-  readFileSync(resolve(process.cwd(), '..', 'package.json'), 'utf-8'),
-);
-const packageVersion = rootPackage.version ?? '0.0.0';
+let packageVersion = '0.0.0';
+
+try {
+  const rootPackage = JSON.parse(
+    readFileSync(resolve(process.cwd(), '..', 'package.json'), 'utf-8'),
+  );
+  packageVersion = rootPackage.version ?? packageVersion;
+} catch (error) {
+  console.error('Unable to read the root package version; using 0.0.0.', error);
+}
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
@@ -20,6 +26,7 @@ const reportGroups = [
   {
     number: '01',
     label: 'Usage',
+    doc: 'cli-reference/',
     question: 'How much did I use?',
     answer: 'Roll up tokens and estimated cost by day, week, or month. Compare two windows or chart a daily trend.',
     commands: ['daily', 'weekly', 'monthly', 'compare', 'trends'],
@@ -27,6 +34,7 @@ const reportGroups = [
   {
     number: '02',
     label: 'Sessions',
+    doc: 'session/',
     question: 'Which work used the most?',
     answer: 'Rank conversations by cost, inspect a matching session ID, or group the same history by repository.',
     commands: ['session', 'session --by-repo'],
@@ -34,6 +42,7 @@ const reportGroups = [
   {
     number: '03',
     label: 'Efficiency',
+    doc: 'efficiency/',
     question: 'How does usage line up with Git?',
     answer: 'Join repo-attributed usage with your commits and line changes. Use the ratios as review signals, with the raw denominators beside them.',
     commands: ['efficiency monthly'],
@@ -41,6 +50,7 @@ const reportGroups = [
   {
     number: '04',
     label: 'Optimize',
+    doc: 'optimize/',
     question: 'What would another model cost?',
     answer: 'Replay the token mix you observed against candidate pricing without changing your source data.',
     commands: ['optimize monthly'],
@@ -48,6 +58,7 @@ const reportGroups = [
   {
     number: '05',
     label: 'Health',
+    doc: 'doctor/',
     question: 'Is my local data healthy?',
     answer: 'Probe every discovery path, inspect the event ledger, and preview retained-history cleanup before deleting anything.',
     commands: ['doctor', 'prune'],
@@ -55,6 +66,7 @@ const reportGroups = [
   {
     number: '06',
     label: 'Wrapped',
+    doc: 'wrapped/',
     question: 'What did the year look like?',
     answer: 'Summarize active days, streaks, models, sources, tokens, and estimated cost in one terminal recap or SVG.',
     commands: ['wrapped'],
@@ -120,15 +132,24 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
 });
 ---
 
-<StarlightPage
-  frontmatter={{
-    title: 'Local usage reports for AI coding tools',
-    description:
-      'Read local sessions from 16 coding tools, normalize usage and pricing, and report what happened without uploading session data.',
-    template: 'splash',
-  }}
->
-  <div class="page-grid" aria-hidden="true"></div>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta
+      name="description"
+      content="Read local sessions from 16 coding tools, normalize usage and pricing, and report what happened without uploading session data."
+    />
+    <meta name="theme-color" content="#171815" data-theme-color />
+    <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
+    <title>LLM Usage Metrics — Local reports for coding agents</title>
+    <script is:inline>
+      const storedTheme = localStorage.getItem('landing-theme');
+      document.documentElement.dataset.theme = storedTheme === 'light' ? 'light' : 'dark';
+    </script>
+  </head>
+  <body>
 
   <main class="landing">
     <nav class="page-nav" aria-label="Landing page">
@@ -141,7 +162,18 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
         <a href="#sources">Sources</a>
         <a href={link('getting-started/')}>Docs</a>
       </div>
-      <a class="page-nav-cta" href={link('getting-started/')}>Start locally <span aria-hidden="true">&#8599;</span></a>
+      <div class="page-nav-actions">
+        <button class="theme-toggle" type="button" aria-label="Use light theme" data-theme-toggle>
+          <svg class="theme-icon theme-icon-light" viewBox="0 0 20 20" aria-hidden="true">
+            <circle cx="10" cy="10" r="3.25"></circle>
+            <path d="M10 1.5v2M10 16.5v2M1.5 10h2M16.5 10h2M4 4l1.4 1.4M14.6 14.6 16 16M16 4l-1.4 1.4M5.4 14.6 4 16"></path>
+          </svg>
+          <svg class="theme-icon theme-icon-dark" viewBox="0 0 20 20" aria-hidden="true">
+            <path d="M16.8 12.4A7 7 0 0 1 7.6 3.2a7 7 0 1 0 9.2 9.2Z"></path>
+          </svg>
+        </button>
+        <a class="page-nav-cta" href={link('getting-started/')}>Start locally <span aria-hidden="true">&#8599;</span></a>
+      </div>
     </nav>
 
     <section class="hero" aria-labelledby="hero-title">
@@ -190,17 +222,6 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
       </div>
 
       <div class="terminal-stage">
-        <div class="terminal-glow" aria-hidden="true"></div>
-        <div class="floating-stat floating-stat-top" aria-hidden="true">
-          <span>this month</span>
-          <strong>$86.40</strong>
-          <small>estimated total</small>
-        </div>
-        <div class="floating-stat floating-stat-bottom" aria-hidden="true">
-          <span class="live-dot"></span>
-          <strong>local only</strong>
-          <small>no session uploads</small>
-        </div>
         <div class="terminal" aria-label="Recording of a monthly usage report in a terminal">
           <div class="terminal-bar">
             <span class="terminal-dots" aria-hidden="true"><i></i><i></i><i></i></span>
@@ -225,15 +246,10 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
       <span class="statusline-spark" aria-hidden="true">▁▂▄▃▆▂▇▅ tokens/day</span>
     </section>
 
-    <div class="source-ticker" aria-label="Supported tools">
-      <span class="source-ticker-label">reads your local history from</span>
-      <div class="source-ticker-track">
-        <div class="source-ticker-set">
-          {doctorSources.map((source) => <span>{source.name}</span>)}
-        </div>
-        <div class="source-ticker-set" aria-hidden="true">
-          {doctorSources.map((source) => <span>{source.name}</span>)}
-        </div>
+    <div class="source-roster" aria-label="Supported tools">
+      <span class="source-roster-label">Reads local history from</span>
+      <div class="source-roster-list">
+        {doctorSources.map((source) => <span>{source.name}</span>)}
       </div>
     </div>
 
@@ -249,7 +265,7 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
 
       <div class="report-list">
         {reportGroups.map((report) => (
-          <article class="report-row">
+          <a class="report-row" href={link(report.doc)} aria-label={`${report.question} Read the ${report.label} documentation`}>
             <div class="report-identity">
               <span class="report-number font-mono">{report.number}</span>
               <span class="report-label">{report.label}</span>
@@ -265,7 +281,7 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
               ))}
             </div>
             <span class="report-arrow" aria-hidden="true">&#8599;</span>
-          </article>
+          </a>
         ))}
       </div>
 
@@ -444,9 +460,28 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
   </footer>
 
   <script is:inline>
+    const themeToggle = document.querySelector('[data-theme-toggle]');
+    const themeColor = document.querySelector('[data-theme-color]');
+
+    const updateThemeControl = () => {
+      const isDark = document.documentElement.dataset.theme === 'dark';
+      themeToggle?.setAttribute('aria-label', isDark ? 'Use light theme' : 'Use dark theme');
+      themeColor?.setAttribute('content', isDark ? '#171815' : '#e9e3d8');
+    };
+
+    themeToggle?.addEventListener('click', () => {
+      const nextTheme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = nextTheme;
+      localStorage.setItem('landing-theme', nextTheme);
+      updateThemeControl();
+    });
+
+    updateThemeControl();
+
     for (const button of document.querySelectorAll('[data-install-command]')) {
       const copyLabel = button.querySelector('[data-copy-label]');
       const copyStatus = document.querySelector('[data-copy-status]');
+      let resetLabelTimeout;
 
       button.addEventListener('click', async () => {
         try {
@@ -458,32 +493,87 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
           if (copyStatus) copyStatus.textContent = 'The install command could not be copied.';
         }
 
-        window.setTimeout(() => {
+        window.clearTimeout(resetLabelTimeout);
+        resetLabelTimeout = window.setTimeout(() => {
           if (copyLabel) copyLabel.textContent = 'Copy';
         }, 2000);
       });
     }
   </script>
-</StarlightPage>
+  </body>
+</html>
 
 <style>
-  :global(main > .content-panel:has(h1#_top)) {
-    display: none !important;
+  :global(html) {
+    scroll-behavior: smooth;
+    color-scheme: dark;
+    background: #171815;
   }
 
-  :global(main > .content-panel) {
-    max-width: 100% !important;
-    padding: 0 !important;
-    border: 0 !important;
+  :global(body) {
+    --color-bg: #171815;
+    --color-bg-elevated: #20211d;
+    --color-bg-card: #1b1c19;
+    --color-bg-code: #121310;
+    --color-text: #eeeae0;
+    --color-text-secondary: #d7d2c7;
+    --color-text-muted: #aaa69c;
+    --color-text-dim: #777970;
+    --color-accent: #cf7453;
+    --color-accent-hover: #df8664;
+    --color-accent-ink: #21140f;
+    --color-accent-subtle: rgba(207, 116, 83, 0.12);
+    --color-cyan: #64a1a9;
+    --color-yellow: #c69e5a;
+    --border-subtle: rgba(238, 234, 224, 0.045);
+    --border-default: rgba(238, 234, 224, 0.1);
+    --border-strong: rgba(238, 234, 224, 0.2);
+    --shadow-color: rgba(4, 5, 3, 0.28);
+    --shadow-elevated: rgba(4, 5, 3, 0.48);
+    margin: 0;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-family: var(--font-sans);
   }
 
-  :global(.sl-container) {
-    max-width: 100% !important;
-    margin: 0 !important;
+  :global(html[data-theme='light']) {
+    color-scheme: light;
+    background: #e9e3d8;
   }
 
-  :global(starlight-menu-button) {
-    display: none !important;
+  :global(html[data-theme='light'] body) {
+    --color-bg: #e9e3d8;
+    --color-bg-elevated: #dfd7ca;
+    --color-bg-card: #f1ece3;
+    --color-bg-code: #dcd3c4;
+    --color-text: #292821;
+    --color-text-secondary: #3d3b32;
+    --color-text-muted: #69665b;
+    --color-text-dim: #898578;
+    --color-accent: #a9472b;
+    --color-accent-hover: #873721;
+    --color-accent-ink: #fffaf2;
+    --color-accent-subtle: rgba(169, 71, 43, 0.1);
+    --color-cyan: #367983;
+    --color-yellow: #8c682c;
+    --border-subtle: rgba(41, 40, 33, 0.05);
+    --border-default: rgba(41, 40, 33, 0.13);
+    --border-strong: rgba(41, 40, 33, 0.24);
+    --shadow-color: rgba(65, 54, 38, 0.08);
+    --shadow-elevated: rgba(38, 33, 25, 0.22);
+  }
+
+  :global(*) {
+    box-sizing: border-box;
+  }
+
+  :global(::selection) {
+    background: var(--color-accent-subtle);
+  }
+
+  :global(:focus-visible) {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 3px;
   }
 
   .landing,
@@ -496,22 +586,17 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
 
   .page-nav {
     position: sticky;
-    top: calc(var(--sl-nav-height) + 0.75rem);
+    top: 0;
     z-index: var(--z-sticky);
     display: grid;
     grid-template-columns: 1fr auto 1fr;
     align-items: center;
-    width: min(100%, 56rem);
-    min-height: 3.25rem;
-    margin: 0.75rem auto -4rem;
-    padding: 0.35rem 0.4rem 0.35rem 1rem;
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-full);
-    background: color-mix(in srgb, var(--color-bg) 78%, transparent);
-    box-shadow:
-      inset 0 1px 0 var(--border-default),
-      0 12px 36px var(--shadow-color);
-    backdrop-filter: blur(18px);
+    width: 100%;
+    min-height: 4rem;
+    margin: 0 auto -4rem;
+    border-bottom: 1px solid var(--border-default);
+    background: color-mix(in srgb, var(--color-bg) 94%, transparent);
+    backdrop-filter: blur(8px);
   }
 
   .page-nav a {
@@ -551,7 +636,7 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
   .page-nav-cta {
     justify-self: end;
     padding: 0.65rem 0.9rem;
-    border-radius: var(--radius-full);
+    border-radius: var(--radius-sm);
     background: var(--color-accent);
     color: var(--color-accent-ink);
     font-size: 0.72rem;
@@ -569,14 +654,56 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     transform: scale(0.98);
   }
 
-  .page-grid {
-    position: fixed;
-    inset: 0;
-    z-index: -1;
-    pointer-events: none;
-    background-image: radial-gradient(var(--border-strong) 1px, transparent 1px);
-    background-size: 2rem 2rem;
-    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 44rem);
+  .page-nav-actions {
+    display: flex;
+    align-items: center;
+    justify-self: end;
+    gap: 0.5rem;
+  }
+
+  .theme-toggle {
+    display: inline-grid;
+    width: 2.35rem;
+    height: 2.35rem;
+    padding: 0;
+    place-items: center;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition:
+      border-color var(--transition-fast),
+      color var(--transition-fast),
+      transform var(--transition-fast);
+  }
+
+  .theme-toggle:hover {
+    border-color: var(--border-strong);
+    color: var(--color-text);
+  }
+
+  .theme-toggle:active {
+    transform: scale(0.96);
+  }
+
+  .theme-icon {
+    width: 1rem;
+    height: 1rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.5;
+  }
+
+  .theme-icon-dark,
+  :global(html[data-theme='light']) .theme-icon-light {
+    display: none;
+  }
+
+  :global(html[data-theme='light']) .theme-icon-dark {
+    display: block;
   }
 
   .section {
@@ -624,12 +751,8 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     grid-template-columns: minmax(0, 1fr) minmax(30rem, 1fr);
     gap: clamp(3rem, 6vw, 6rem);
     align-items: center;
-    min-height: calc(100dvh - var(--sl-nav-height));
+    min-height: 100dvh;
     padding-block: clamp(4rem, 10vw, 8rem);
-  }
-
-  .hero-copy {
-    animation: enter 600ms var(--ease-out) both;
   }
 
   .release-link {
@@ -650,7 +773,6 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     height: 0.45rem;
     border-radius: 50%;
     background: var(--color-accent);
-    animation: pulse 2.4s ease-in-out infinite;
   }
 
   .hero .eyebrow {
@@ -682,9 +804,7 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     background: currentColor;
     content: '';
     opacity: 0.45;
-    transform: scaleX(0);
-    transform-origin: left;
-    animation: draw-line 700ms 700ms var(--ease-out) forwards;
+    transform: rotate(-1.5deg);
   }
 
   .hero-summary {
@@ -803,19 +923,6 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
 
   .terminal-stage {
     position: relative;
-    perspective: 1000px;
-  }
-
-  .terminal-glow {
-    position: absolute;
-    inset: -12% -8%;
-    z-index: -1;
-    background: radial-gradient(
-      ellipse at 60% 40%,
-      color-mix(in srgb, var(--color-accent) 22%, transparent),
-      transparent 65%
-    );
-    filter: blur(48px);
   }
 
   .terminal {
@@ -833,66 +940,7 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     border: 1px solid var(--term-border);
     border-radius: var(--radius-lg);
     background: var(--term-bg);
-    box-shadow: 0 32px 80px -40px var(--shadow-elevated);
-    animation: terminal-enter 800ms 120ms var(--ease-out) both;
-    transform-origin: center left;
-  }
-
-  .floating-stat {
-    position: absolute;
-    z-index: 2;
-    display: grid;
-    min-width: 9.5rem;
-    padding: 0.85rem 1rem;
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-md);
-    background: color-mix(in srgb, var(--color-bg-elevated) 88%, transparent);
-    box-shadow:
-      inset 0 1px 0 var(--border-default),
-      0 18px 35px var(--shadow-color);
-    backdrop-filter: blur(14px);
-    font-family: var(--font-mono);
-    animation: float 5s ease-in-out infinite;
-  }
-
-  .floating-stat-top {
-    top: -2.4rem;
-    right: -1.5rem;
-  }
-
-  .floating-stat-bottom {
-    right: 1.25rem;
-    bottom: -2.25rem;
-    grid-template-columns: auto 1fr;
-    column-gap: 0.55rem;
-    animation-delay: -2.2s;
-  }
-
-  .floating-stat > span:not(.live-dot),
-  .floating-stat small {
-    color: var(--color-text-dim);
-    font-size: 0.58rem;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-  }
-
-  .floating-stat strong {
-    color: var(--color-text);
-    font-size: 1.05rem;
-  }
-
-  .floating-stat-bottom small {
-    grid-column: 2;
-  }
-
-  .live-dot {
-    grid-row: 1 / span 2;
-    align-self: center;
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 50%;
-    background: var(--color-accent);
-    box-shadow: 0 0 0 4px var(--color-accent-subtle);
+    box-shadow: 0.75rem 0.75rem 0 var(--border-default);
   }
 
   .terminal-bar {
@@ -951,10 +999,6 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     white-space: pre;
   }
 
-  .t-line[style] {
-    animation: t-print 0.25s var(--ease-out) var(--d) backwards;
-  }
-
   .t-cmd {
     margin-bottom: 0.35rem;
   }
@@ -965,7 +1009,6 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     width: 39ch;
     vertical-align: bottom;
     white-space: nowrap;
-    animation: t-type 1.5s steps(39) 0.4s both;
   }
 
   .t-prompt {
@@ -1011,7 +1054,6 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     height: 1.15em;
     vertical-align: text-bottom;
     background: var(--term-accent);
-    animation: t-blink 1.1s steps(1) infinite;
   }
 
   /* ---------- statusline ---------- */
@@ -1049,17 +1091,16 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     letter-spacing: 0.05em;
   }
 
-  .source-ticker {
+  .source-roster {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr);
     align-items: center;
     gap: 1.5rem;
-    padding-block: 1rem;
-    overflow: hidden;
+    padding-block: 1.25rem;
     border-bottom: 1px solid var(--border-default);
   }
 
-  .source-ticker-label {
+  .source-roster-label {
     color: var(--color-text-dim);
     font-family: var(--font-mono);
     font-size: 0.62rem;
@@ -1068,24 +1109,14 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     white-space: nowrap;
   }
 
-  .source-ticker-track {
+  .source-roster-list {
     display: flex;
-    width: max-content;
-    min-width: 100%;
-    overflow: hidden;
-    mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.55rem 1.4rem;
   }
 
-  .source-ticker-set {
-    display: flex;
-    flex-shrink: 0;
-    gap: 2rem;
-    min-width: max-content;
-    padding-right: 2rem;
-    animation: ticker 36s linear infinite;
-  }
-
-  .source-ticker-set span {
+  .source-roster-list span {
     color: var(--color-text-muted);
     font-family: var(--font-mono);
     font-size: 0.72rem;
@@ -1141,6 +1172,8 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     border-right: 1px solid var(--border-default);
     border-bottom: 1px solid var(--border-default);
     background: color-mix(in srgb, var(--color-bg-card) 34%, transparent);
+    color: inherit;
+    text-decoration: none;
     transition:
       background var(--transition-base),
       transform var(--transition-base);
@@ -1162,13 +1195,15 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
       transform var(--transition-slow);
   }
 
-  .report-row:hover {
+  .report-row:hover,
+  .report-row:focus-visible {
     z-index: 1;
     background: var(--color-bg-elevated);
     transform: translateY(-0.25rem);
   }
 
-  .report-row:hover::before {
+  .report-row:hover::before,
+  .report-row:focus-visible::before {
     opacity: 1;
     transform: scale(1);
   }
@@ -1206,7 +1241,8 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     transition: color var(--transition-fast);
   }
 
-  .report-row:hover .report-number {
+  .report-row:hover .report-number,
+  .report-row:focus-visible .report-number {
     color: var(--color-accent);
   }
 
@@ -1277,7 +1313,8 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
       transform var(--transition-fast);
   }
 
-  .report-row:hover .report-arrow {
+  .report-row:hover .report-arrow,
+  .report-row:focus-visible .report-arrow {
     color: var(--color-accent);
     opacity: 1;
     transform: translate(0, 0);
@@ -1668,91 +1705,6 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     clip-path: inset(50%);
   }
 
-  /* ---------- animation ---------- */
-
-  @keyframes enter {
-    from {
-      opacity: 0;
-      transform: translateY(1rem);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  @keyframes terminal-enter {
-    from {
-      opacity: 0;
-      transform: translateY(1.5rem) rotateY(-4deg) rotateX(2deg);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0) rotateY(0) rotateX(0);
-    }
-  }
-
-  @keyframes draw-line {
-    to {
-      transform: scaleX(1);
-    }
-  }
-
-  @keyframes float {
-    0%,
-    100% {
-      transform: translateY(0);
-    }
-    50% {
-      transform: translateY(-0.45rem);
-    }
-  }
-
-  @keyframes ticker {
-    to {
-      transform: translateX(-100%);
-    }
-  }
-
-  @keyframes pulse {
-    0%,
-    100% {
-      box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-accent) 45%, transparent);
-    }
-    50% {
-      box-shadow: 0 0 0 5px transparent;
-    }
-  }
-
-  @keyframes t-print {
-    from {
-      opacity: 0;
-    }
-  }
-
-  @keyframes t-type {
-    from {
-      width: 0;
-    }
-    to {
-      width: 39ch;
-    }
-  }
-
-  @keyframes t-blink {
-    50% {
-      opacity: 0;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .t-line[style],
-    .t-typed {
-      animation: none;
-      width: auto;
-    }
-  }
-
   /* ---------- responsive ---------- */
 
   @media (max-width: 980px) {
@@ -1800,7 +1752,7 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
     }
 
     .page-nav {
-      top: calc(var(--sl-nav-height) + 0.5rem);
+      top: 0;
       grid-template-columns: 1fr auto;
       width: calc(100% - 0.5rem);
       margin-bottom: -5rem;
@@ -1847,19 +1799,13 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
       display: none;
     }
 
-    .source-ticker {
+    .source-roster {
       grid-template-columns: 1fr;
       gap: 0.75rem;
     }
 
-    .floating-stat-top {
-      top: -1.5rem;
-      right: -0.5rem;
-    }
-
-    .floating-stat-bottom {
-      right: 0.75rem;
-      bottom: -2rem;
+    .source-roster-list {
+      justify-content: flex-start;
     }
 
     .section-heading {
@@ -1942,10 +1888,6 @@ const heatCells = Array.from({ length: HEAT_WEEKS * 7 }, (_, i) => {
   }
 
   @media (max-width: 430px) {
-    .floating-stat {
-      display: none;
-    }
-
     .terminal-body {
       font-size: 0.58rem;
     }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,877 +3,1280 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-const rootPkg = JSON.parse(
+const rootPackage = JSON.parse(
   readFileSync(resolve(process.cwd(), '..', 'package.json'), 'utf-8'),
 );
-const pkgVersion = rootPkg.version ?? '0.0.0';
+const packageVersion = rootPackage.version ?? '0.0.0';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
-
 const link = (slug: string) => `${base}${slug}`;
-const ghUrl = 'https://github.com/ayagmar/llm-usage-metrics';
+
+const githubUrl = 'https://github.com/ayagmar/llm-usage-metrics';
 const npmUrl = 'https://www.npmjs.com/package/llm-usage-metrics';
+
+const reportGroups = [
+  {
+    number: '01',
+    question: 'How much did I use?',
+    answer: 'Roll up tokens and estimated cost by day, week, or month. Compare two windows or chart a daily trend.',
+    commands: ['daily', 'weekly', 'monthly', 'compare', 'trends'],
+  },
+  {
+    number: '02',
+    question: 'Which work used the most?',
+    answer: 'Rank conversations by cost, inspect a matching session ID, or group the same history by repository.',
+    commands: ['session', 'session --by-repo'],
+  },
+  {
+    number: '03',
+    question: 'How does usage line up with Git?',
+    answer: 'Join repo-attributed usage with your commits and line changes. Use the ratios as review signals, with the raw denominators beside them.',
+    commands: ['efficiency monthly'],
+  },
+  {
+    number: '04',
+    question: 'What would another model cost?',
+    answer: 'Replay the token mix you observed against candidate pricing without changing your source data.',
+    commands: ['optimize monthly'],
+  },
+  {
+    number: '05',
+    question: 'Is my local data healthy?',
+    answer: 'Probe every discovery path, inspect the event ledger, and preview retained-history cleanup before deleting anything.',
+    commands: ['doctor', 'prune'],
+  },
+  {
+    number: '06',
+    question: 'What did the year look like?',
+    answer: 'Summarize active days, streaks, models, sources, tokens, and estimated cost in one terminal recap or SVG.',
+    commands: ['wrapped'],
+  },
+];
+
+const sourceGroups = [
+  {
+    format: 'JSONL',
+    sources: ['pi', 'codex', 'OpenClaw', 'Claude Code', 'Copilot CLI', 'Qwen CLI', 'Kimi'],
+  },
+  {
+    format: 'JSON',
+    sources: ['Gemini CLI', 'Droid CLI', 'Amp', 'Cline', 'RooCode', 'KiloCode'],
+  },
+  {
+    format: 'SQLite',
+    sources: ['OpenCode', 'Goose', 'Antigravity'],
+  },
+];
 ---
 
-<StarlightPage frontmatter={{ title: 'Overview', template: 'splash' }}>
-  <div class="grid-bg" aria-hidden="true"></div>
-  <div class="hero-glow" aria-hidden="true"></div>
+<StarlightPage
+  frontmatter={{
+    title: 'Local usage reports for AI coding tools',
+    description:
+      'Read local sessions from 16 coding tools, normalize usage and pricing, and report what happened without uploading session data.',
+    template: 'splash',
+  }}
+>
+  <div class="page-grid" aria-hidden="true"></div>
 
-  <!-- ─── Hero ─── -->
-  <section class="hero fade-up">
-    <a
-      href={`${ghUrl}/releases`}
-      class="version-pill font-mono"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <span class="dot"></span>v{pkgVersion}
-    </a>
-
-    <h1 class="headline">
-      Know what your<br />
-      <span class="dim">AI coding costs.</span>
-    </h1>
-
-    <p class="subtitle">
-      Local-first usage metrics for every AI coding agent.
-      Token counts, real pricing, Git&#8209;correlated ROI — sub&#8209;second reports.
-    </p>
-
-    <div class="actions">
-      <div
-        class="install-box"
-        role="button"
-        tabindex="0"
-        aria-label="Copy install command"
-      >
-        <span class="prompt text-dim">$</span>
-        <code class="cmd font-mono">npm i -g llm-usage-metrics</code>
-        <span class="copy-icon" aria-hidden="true">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-        </span>
-      </div>
-
-      <div class="btn-row">
-        <a href={link('getting-started/')} class="btn btn-primary">Get started</a>
-        <a href={ghUrl} class="btn btn-secondary" target="_blank" rel="noopener noreferrer">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
-          GitHub
+  <main class="landing">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="hero-copy">
+        <a
+          class="release-link label"
+          href={`${githubUrl}/releases`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span class="release-mark" aria-hidden="true"></span>
+          Version {packageVersion}
         </a>
-      </div>
-    </div>
-  </section>
 
-  <!-- ─── Terminal preview ─── -->
-  <section class="terminal-section reveal">
-    <div class="terminal">
-      <div class="terminal-bar">
-        <div class="terminal-dots">
-          <span class="td" style="background:#f87171"></span>
-          <span class="td" style="background:#fbbf24"></span>
-          <span class="td" style="background:#4ade80"></span>
+        <p class="eyebrow">Local usage intelligence for AI coding tools</p>
+        <h1 id="hero-title">See how your coding agents use tokens.</h1>
+        <p class="hero-summary">
+          Read local sessions from 16 tools, normalize usage and pricing, and turn the result
+          into reports you can inspect, compare, or export. Your session data stays on your
+          machine.
+        </p>
+
+        <div class="hero-actions">
+          <a class="button button-primary" href={link('getting-started/')}>Start with one report</a>
+          <a
+            class="button button-secondary"
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View source
+          </a>
         </div>
-        <span class="terminal-title font-mono">llm-usage daily</span>
+
+        <button
+          class="install-command"
+          type="button"
+          aria-label="Copy the npm install command"
+          data-install-command
+        >
+          <span class="prompt" aria-hidden="true">$</span>
+          <code>npm install -g llm-usage-metrics</code>
+          <span class="copy-label" data-copy-label>Copy</span>
+        </button>
+        <p class="sr-only" aria-live="polite" data-copy-status></p>
       </div>
-      <pre class="terminal-body font-mono"><code><span class="t-dim">$</span> llm-usage daily
 
-<span class="t-head">  Period      Source   Models              Input    Output   Total      Cost</span>
-<span class="t-sep">  ──────────  ───────  ──────────────────  ───────  ───────  ───────  ──────</span>
-  <span class="t-date">2026-03-02</span>  <span class="t-source">pi</span>       <span class="t-model">• claude-sonnet-4</span>   <span class="t-num">142,319</span>   <span class="t-num">38,104</span>  <span class="t-num">180,423</span>  <span class="t-cost">$1.57</span>
-  <span class="t-date">2026-03-02</span>  <span class="t-source">codex</span>    <span class="t-model">• claude-sonnet-4</span>    <span class="t-num">98,712</span>   <span class="t-num">21,401</span>  <span class="t-num">120,113</span>  <span class="t-cost">$1.02</span>
-  <span class="t-date">2026-03-02</span>  <span class="t-source">gemini</span>   <span class="t-model">• gemini-2.5-pro</span>     <span class="t-num">67,241</span>   <span class="t-num">15,832</span>   <span class="t-num">83,073</span>  <span class="t-cost">$0.44</span>
-  <span class="t-date">2026-03-02</span>  <span class="t-source">codex</span>    <span class="t-model">• o3</span>                 <span class="t-num">31,049</span>    <span class="t-num">8,198</span>   <span class="t-num">39,247</span>  <span class="t-cost">$0.41</span>
-<span class="t-sep">  ──────────  ───────  ──────────────────  ───────  ───────  ───────  ──────</span>
-  <span class="t-total">ALL         TOTAL    4 models            339,321   83,535  422,856  <span class="t-cost-total">$3.44</span></span></code></pre>
-    </div>
-  </section>
+      <div class="report-preview" aria-label="Shortened example of a monthly usage report">
+        <div class="preview-header">
+          <div>
+            <span class="preview-kicker label">Example output</span>
+            <span class="preview-title">monthly usage</span>
+          </div>
+          <span class="preview-status label">local</span>
+        </div>
 
-  <!-- ─── Speed comparison ─── -->
-  <section class="speed-section reveal">
-    <h2 class="section-title">Blazing fast.</h2>
-    <p class="section-desc">
-      Benchmarked against ccusage on real production data.
-    </p>
+        <div class="preview-command font-mono">
+          <span aria-hidden="true">$</span> llm-usage monthly --source codex,claude
+        </div>
 
-    <div class="speed-grid">
-      <div class="speed-card">
-        <div class="speed-number font-mono">4.6<span class="speed-x">×</span></div>
-        <div class="speed-label">faster cold start</div>
-        <div class="speed-detail font-mono">3.6s vs 16.8s</div>
+        <div class="preview-table" role="table" aria-label="Usage report sample">
+          <div class="preview-row preview-table-head" role="row">
+            <span role="columnheader">Source</span>
+            <span role="columnheader">Models</span>
+            <span role="columnheader">Tokens</span>
+            <span role="columnheader">Cost</span>
+          </div>
+          <div class="preview-row" role="row">
+            <span class="source-name" role="cell">codex</span>
+            <span role="cell">2 models</span>
+            <span role="cell">91.4M</span>
+            <span role="cell">$54.12</span>
+          </div>
+          <div class="preview-row" role="row">
+            <span class="source-name" role="cell">claude</span>
+            <span role="cell">2 models</span>
+            <span role="cell">51.4M</span>
+            <span role="cell">~$32.28</span>
+          </div>
+          <div class="preview-row preview-total" role="row">
+            <span role="cell">combined</span>
+            <span role="cell">4 models</span>
+            <span role="cell">142.8M</span>
+            <span role="cell">~$86.40</span>
+          </div>
+        </div>
+
+        <div class="preview-foot">
+          <span><i aria-hidden="true"></i> 2 sources parsed</span>
+          <span>pricing partly estimated</span>
+        </div>
       </div>
-      <div class="speed-card speed-highlight">
-        <div class="speed-number font-mono">22<span class="speed-x">×</span></div>
-        <div class="speed-label">faster with cache</div>
-        <div class="speed-detail font-mono">0.7s vs 17.0s</div>
+    </section>
+
+    <section class="fact-strip" aria-label="Product facts">
+      <div>
+        <strong>16</strong>
+        <span>source adapters</span>
       </div>
-      <div class="speed-card">
-        <div class="speed-number font-mono">&lt;1<span class="speed-x">s</span></div>
-        <div class="speed-label">cached reports</div>
-        <div class="speed-detail font-mono">sub-second</div>
+      <div>
+        <strong>Local</strong>
+        <span>session processing</span>
       </div>
-    </div>
+      <div>
+        <strong>Offline</strong>
+        <span>pricing snapshot included</span>
+      </div>
+      <div>
+        <strong>4</strong>
+        <span>output families</span>
+      </div>
+    </section>
 
-    <a href={link('benchmarks/')} class="section-link">View full benchmarks →</a>
-  </section>
-
-  <!-- ─── Commands ─── -->
-  <section class="commands-section reveal">
-    <h2 class="section-title">Four commands. Full visibility.</h2>
-    <p class="section-desc">
-      Usage rollups, Git-correlated efficiency, pricing optimization, and daily trend visibility.
-    </p>
-
-    <div class="cmd-grid">
-      <div class="cmd-card">
-        <div class="cmd-icon">📊</div>
-        <h3 class="cmd-name">Usage reports</h3>
-        <p class="cmd-desc">
-          Aggregate token counts and costs across all agents.
-          Daily, weekly, or monthly.
+    <section class="reports section" aria-labelledby="reports-title">
+      <div class="section-heading">
+        <p class="eyebrow">Choose the question first</p>
+        <h2 id="reports-title">A report for the work you want to understand.</h2>
+        <p>
+          Start with a calendar rollup, then move to sessions, repositories, or candidate
+          pricing when you need a narrower answer.
         </p>
-        <pre class="cmd-code font-mono"><code>llm-usage monthly \
-  --provider openai</code></pre>
       </div>
 
-      <div class="cmd-card">
-        <div class="cmd-icon">⚡</div>
-        <h3 class="cmd-name">Efficiency</h3>
-        <p class="cmd-desc">
-          Correlate LLM spend with Git outcomes.
-          $/commit, $/1k lines, tokens per commit.
+      <div class="report-list">
+        {reportGroups.map((report) => (
+          <article class="report-row">
+            <span class="report-number font-mono">{report.number}</span>
+            <h3>{report.question}</h3>
+            <p>{report.answer}</p>
+            <div class="command-list">
+              {report.commands.map((command) => <code>llm-usage {command}</code>)}
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <a class="text-link" href={link('cli-reference/')}>Browse every command and option</a>
+    </section>
+
+    <section class="sources section" aria-labelledby="sources-title">
+      <div class="sources-copy">
+        <p class="eyebrow">Different files, one event model</p>
+        <h2 id="sources-title">Sixteen sources without sixteen reporting workflows.</h2>
+        <p>
+          Each adapter discovers its tool's local data and converts it into the same usage
+          event shape. Filters, pricing, aggregation, and exports work the same way after that
+          boundary.
         </p>
-        <pre class="cmd-code font-mono"><code>llm-usage efficiency monthly \
-  --repo-dir .</code></pre>
+        <a class="text-link" href={link('sources/')}>See discovery paths and overrides</a>
       </div>
 
-      <div class="cmd-card">
-        <div class="cmd-icon">📈</div>
-        <h3 class="cmd-name">Trends</h3>
-        <p class="cmd-desc">
-          Track daily cost or token movement over time.
-          Combined view or source-by-source.
+      <div class="source-groups">
+        {sourceGroups.map((group) => (
+          <div class="source-group">
+            <span class="source-format label">{group.format}</span>
+            <ul>
+              {group.sources.map((source) => <li>{source}</li>)}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+
+    <section class="pipeline section" aria-labelledby="pipeline-title">
+      <div class="section-heading pipeline-heading">
+        <p class="eyebrow">Designed for repeatable reports</p>
+        <h2 id="pipeline-title">The useful engineering sits between the files and the table.</h2>
+      </div>
+
+      <div class="pipeline-layout">
+        <ol class="pipeline-flow">
+          <li>
+            <span class="flow-index font-mono">01</span>
+            <div>
+              <strong>Discover</strong>
+              <p>Find default source locations or apply the paths in your TOML config.</p>
+            </div>
+          </li>
+          <li>
+            <span class="flow-index font-mono">02</span>
+            <div>
+              <strong>Normalize</strong>
+              <p>Convert source-specific records into deterministic usage events.</p>
+            </div>
+          </li>
+          <li>
+            <span class="flow-index font-mono">03</span>
+            <div>
+              <strong>Price</strong>
+              <p>Keep explicit cost or estimate it from cached LiteLLM data.</p>
+            </div>
+          </li>
+          <li>
+            <span class="flow-index font-mono">04</span>
+            <div>
+              <strong>Report</strong>
+              <p>Aggregate once, then render terminal, JSON, Markdown, or SVG output.</p>
+            </div>
+          </li>
+        </ol>
+
+        <div class="pipeline-notes">
+          <article>
+            <span class="note-label label">Persistent ledger</span>
+            <h3>Unchanged files do not need another parse.</h3>
+            <p>
+              A local SQLite event store keeps normalized events and parse diagnostics. It also
+              powers optional history for session files that have left the disk.
+            </p>
+            <a href={link('architecture/event-store/')}>How the event store works</a>
+          </article>
+          <article>
+            <span class="note-label label">Honest pricing</span>
+            <h3>Unknown cost stays unknown.</h3>
+            <p>
+              Reports mark partial estimates with <code>~</code> and unresolved rows with
+              <code>-</code>. The cost engine does not invent a rate for a token bucket it cannot
+              price.
+            </p>
+            <a href={link('pricing/')}>Read the pricing rules</a>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="benchmark section" aria-labelledby="benchmark-title">
+      <div class="benchmark-copy">
+        <p class="eyebrow">Published with the slower runs included</p>
+        <h2 id="benchmark-title">Performance numbers you can audit.</h2>
+        <p>
+          The benchmark records five-run medians on real local corpora and publishes the machine,
+          commands, cache state, and dataset size. Cold runs favor the native Rust comparison tool;
+          the warm Claude run favors the local event store.
         </p>
-        <pre class="cmd-code font-mono"><code>llm-usage trends \
-  --metric tokens</code></pre>
+        <a class="text-link" href={link('benchmarks/')}>Read the benchmark and reproduce it</a>
       </div>
 
-      <div class="cmd-card">
-        <div class="cmd-icon">🔬</div>
-        <h3 class="cmd-name">Optimize</h3>
-        <p class="cmd-desc">
-          Replay your token mix against candidate models.
-          Find cheaper alternatives instantly.
-        </p>
-        <pre class="cmd-code font-mono"><code>llm-usage optimize monthly \
-  --candidate-model gpt-4.1</code></pre>
-      </div>
-    </div>
-  </section>
+      <dl class="benchmark-data">
+        <div>
+          <dt>Largest measured corpus</dt>
+          <dd>1.8 GiB</dd>
+          <span>1,145 codex session files</span>
+        </div>
+        <div>
+          <dt>Warm Claude median</dt>
+          <dd>0.256 s</dd>
+          <span>201 files in the measured corpus</span>
+        </div>
+        <div>
+          <dt>Runs per cell</dt>
+          <dd>5</dd>
+          <span>median, mean, min, and max published</span>
+        </div>
+      </dl>
+    </section>
 
-  <!-- ─── Sources ─── -->
-  <section class="sources-section reveal">
-    <h2 class="section-title">Every agent. Zero config.</h2>
-    <p class="section-desc">
-      Auto-discovers session data from five AI coding tools.
-    </p>
-
-    <div class="source-strip">
-      <a href={link('sources/pi/')} class="source-chip">
-        <span class="source-dot" style="background:#10b981"></span>pi
-      </a>
-      <a href={link('sources/codex/')} class="source-chip">
-        <span class="source-dot" style="background:#38bdf8"></span>codex
-      </a>
-      <a href={link('sources/gemini/')} class="source-chip">
-        <span class="source-dot" style="background:#818cf8"></span>gemini
-      </a>
-      <a href={link('sources/droid/')} class="source-chip">
-        <span class="source-dot" style="background:#fb923c"></span>droid
-      </a>
-      <a href={link('sources/opencode/')} class="source-chip">
-        <span class="source-dot" style="background:#f472b6"></span>opencode
-      </a>
-    </div>
-  </section>
-
-  <!-- ─── Metrics bar ─── -->
-  <section class="metrics-section reveal">
-    <div class="metrics-bar">
-      <div class="metric">
-        <span class="metric-val font-mono">100%</span>
-        <span class="metric-label">local-first</span>
+    <section class="final-cta section" aria-labelledby="cta-title">
+      <div>
+        <p class="eyebrow">One command is enough to start</p>
+        <h2 id="cta-title">Run the report against the sessions already on your machine.</h2>
       </div>
-      <div class="metric-sep"></div>
-      <div class="metric">
-        <span class="metric-val font-mono">0</span>
-        <span class="metric-label">telemetry</span>
+      <div class="cta-actions">
+        <a class="button button-primary" href={link('getting-started/')}>Open the setup guide</a>
+        <a class="button button-secondary" href={npmUrl} target="_blank" rel="noopener noreferrer"
+          >View on npm</a
+        >
       </div>
-      <div class="metric-sep"></div>
-      <div class="metric">
-        <span class="metric-val font-mono">3</span>
-        <span class="metric-label">output formats</span>
-      </div>
-      <div class="metric-sep"></div>
-      <div class="metric">
-        <span class="metric-val font-mono">O(1)</span>
-        <span class="metric-label">event store</span>
-      </div>
-    </div>
-  </section>
+    </section>
+  </main>
 
-  <!-- ─── Footer ─── -->
-  <footer class="footer">
-    <div class="footer-top">
-      <div class="footer-brand">
-        <svg width="20" height="20" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <rect width="32" height="32" rx="8" fill="#10b981"/>
-          <path d="M8 12h16M8 16h12M8 20h8" stroke="#09090b" stroke-width="2" stroke-linecap="round"/>
-        </svg>
-        <span class="font-mono footer-name">llm-usage-metrics</span>
-      </div>
-
-      <nav class="footer-nav">
-        <a href={link('getting-started/')}>Docs</a>
-        <a href={link('cli-reference/')}>CLI</a>
-        <a href={link('benchmarks/')}>Benchmarks</a>
-        <a href={ghUrl} target="_blank" rel="noopener noreferrer">GitHub</a>
-        <a href={npmUrl} target="_blank" rel="noopener noreferrer">npm</a>
-      </nav>
-    </div>
-
-    <div class="footer-bottom">
-      <span class="text-dim">
-        Built for engineers who want to know what their AI coding actually costs.
-      </span>
-    </div>
+  <footer class="landing-footer">
+    <a class="footer-brand" href={base} aria-label="LLM Usage Metrics home">
+      <svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true">
+        <rect x="1" y="1" width="30" height="30" rx="8" fill="currentColor"></rect>
+        <path d="M8 10.5 12.5 16 8 21.5M16 21.5h8M17 10.5h7" fill="none" stroke="var(--color-bg)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+      </svg>
+      <span>llm-usage-metrics</span>
+    </a>
+    <nav aria-label="Footer">
+      <a href={link('getting-started/')}>Docs</a>
+      <a href={link('cli-reference/')}>CLI reference</a>
+      <a href={githubUrl} target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href={npmUrl} target="_blank" rel="noopener noreferrer">npm</a>
+    </nav>
+    <p>Local-first usage reporting for AI coding tools. MIT licensed.</p>
   </footer>
 
-  <!-- Scripts -->
   <script is:inline>
-    // Copy install command
-    const box = document.querySelector('.install-box');
-    box?.addEventListener('click', () => {
-      if (!navigator.clipboard?.writeText) return;
-      navigator.clipboard.writeText('npm i -g llm-usage-metrics').then(() => {
-        const icon = box.querySelector('.copy-icon');
-        if (!icon) return;
-        icon.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>';
-        setTimeout(() => {
-          icon.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
-        }, 2000);
-      }).catch(() => {});
-    });
-    box?.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); box.click(); }
-    });
+    const installButton = document.querySelector('[data-install-command]');
+    const copyLabel = document.querySelector('[data-copy-label]');
+    const copyStatus = document.querySelector('[data-copy-status]');
 
-    // Scroll reveal animation
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('visible');
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.15, rootMargin: '0px 0px -40px 0px' }
-    );
-    document.querySelectorAll('.reveal').forEach((el) => observer.observe(el));
+    installButton?.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText('npm install -g llm-usage-metrics');
+        if (copyLabel) copyLabel.textContent = 'Copied';
+        if (copyStatus) copyStatus.textContent = 'Install command copied.';
+      } catch {
+        if (copyLabel) copyLabel.textContent = 'Copy failed';
+        if (copyStatus) copyStatus.textContent = 'The install command could not be copied.';
+      }
+
+      window.setTimeout(() => {
+        if (copyLabel) copyLabel.textContent = 'Copy';
+      }, 2000);
+    });
   </script>
 </StarlightPage>
 
 <style>
-  /* ── Starlight splash overrides ── */
-  :global(main > .content-panel:has(h1#_top)) { display: none !important; }
-  :global(main > .content-panel) { padding: 0 !important; max-width: 100% !important; border: none !important; }
-  :global(.sl-container) { max-width: 100% !important; margin: 0 !important; }
-  :global(starlight-menu-button) { display: none !important; }
+  :global(main > .content-panel:has(h1#_top)) {
+    display: none !important;
+  }
 
-  /* ── Grid background ── */
-  .grid-bg {
+  :global(main > .content-panel) {
+    max-width: 100% !important;
+    padding: 0 !important;
+    border: 0 !important;
+  }
+
+  :global(.sl-container) {
+    max-width: 100% !important;
+    margin: 0 !important;
+  }
+
+  :global(starlight-menu-button) {
+    display: none !important;
+  }
+
+  .landing,
+  .landing-footer {
+    position: relative;
+    max-width: 1240px;
+    margin-inline: auto;
+    padding-inline: clamp(1.25rem, 4vw, 3rem);
+  }
+
+  .page-grid {
     position: fixed;
     inset: 0;
     z-index: -1;
     pointer-events: none;
     background-image:
-      linear-gradient(to right, var(--border-default) 1px, transparent 1px),
-      linear-gradient(to bottom, var(--border-default) 1px, transparent 1px);
-    background-size: 3rem 3rem;
-    mask-image: radial-gradient(ellipse 70% 60% at 50% 0%, black 0%, transparent 100%);
-    -webkit-mask-image: radial-gradient(ellipse 70% 60% at 50% 0%, black 0%, transparent 100%);
-  }
-  :root[data-theme='light'] .grid-bg { opacity: 0.2; }
-
-  /* ── Hero glow ── */
-  .hero-glow {
-    position: fixed;
-    top: -20%;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 800px;
-    height: 600px;
-    background: radial-gradient(ellipse at center, rgba(16, 185, 129, 0.06) 0%, transparent 70%);
-    z-index: -1;
-    pointer-events: none;
-  }
-  :root[data-theme='light'] .hero-glow {
-    background: radial-gradient(ellipse at center, rgba(16, 185, 129, 0.04) 0%, transparent 70%);
+      linear-gradient(to right, var(--border-subtle) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--border-subtle) 1px, transparent 1px);
+    background-size: 4rem 4rem;
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), transparent 48rem);
   }
 
-  /* ── Animations ── */
-  @keyframes fade-up {
-    from { opacity: 0; transform: translateY(24px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-  .fade-up {
-    animation: fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  .section {
+    padding-block: clamp(5rem, 10vw, 8.5rem);
+    border-top: 1px solid var(--border-default);
   }
 
-  .reveal {
-    opacity: 0;
-    transform: translateY(32px);
-    transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
-                transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
-  }
-  .reveal.visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  /* ── Section container (centered) ── */
-  section, footer {
-    max-width: var(--max-w-container);
-    margin-left: auto;
-    margin-right: auto;
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-  }
-
-  .section-title {
-    font-size: var(--text-2xl);
+  .eyebrow,
+  .label {
+    margin: 0;
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
     font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  h1,
+  h2,
+  h3,
+  p {
+    margin-top: 0;
+  }
+
+  h1,
+  h2,
+  h3 {
+    color: var(--color-text);
     letter-spacing: var(--tracking-tighter);
-    margin-bottom: var(--space-2);
-    text-align: center;
-  }
-  .section-desc {
-    color: var(--color-text-muted);
-    font-size: var(--text-base);
-    text-align: center;
-    margin-bottom: var(--space-10);
-    max-width: 48ch;
-    margin-left: auto;
-    margin-right: auto;
-  }
-  .section-link {
-    display: block;
-    text-align: center;
-    margin-top: var(--space-8);
-    font-size: var(--text-sm);
-    font-weight: 500;
-    color: var(--color-text-muted);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-  }
-  .section-link:hover { color: var(--color-text); }
-
-  @media (min-width: 768px) {
-    .section-title { font-size: var(--text-3xl); }
   }
 
-  /* ═══════════════════════════════
-     HERO
-     ═══════════════════════════════ */
+  h2 {
+    max-width: 18ch;
+    margin-bottom: 1.25rem;
+    font-size: clamp(2rem, 4vw, 3.5rem);
+    font-weight: 600;
+    line-height: 1.02;
+  }
+
   .hero {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: minmax(0, 0.9fr) minmax(32rem, 1.1fr);
+    gap: clamp(3rem, 7vw, 7rem);
     align-items: center;
-    text-align: center;
-    padding-top: var(--space-12);
-    padding-bottom: var(--space-12);
-  }
-  @media (min-width: 768px) {
-    .hero { padding-top: var(--space-16); padding-bottom: var(--space-16); }
-  }
-  @media (min-width: 1024px) {
-    .hero { padding-top: var(--space-20); padding-bottom: var(--space-16); }
+    min-height: calc(100dvh - var(--sl-nav-height));
+    padding-block: clamp(4rem, 10vw, 8rem);
   }
 
-  .version-pill {
+  .hero-copy {
+    animation: enter 600ms var(--ease-out) both;
+  }
+
+  .release-link {
     display: inline-flex;
     align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-1) var(--space-3);
-    font-size: var(--text-xs);
-    font-weight: 500;
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-full);
+    gap: 0.55rem;
+    margin-bottom: 3.5rem;
     color: var(--color-text-muted);
     text-decoration: none;
-    transition: all var(--transition-fast);
-    margin-bottom: var(--space-6);
   }
-  .version-pill:hover {
-    border-color: var(--color-text-dim);
+
+  .release-link:hover {
     color: var(--color-text);
   }
-  .dot {
-    width: 6px; height: 6px;
+
+  .release-mark {
+    width: 0.45rem;
+    height: 0.45rem;
     border-radius: 50%;
-    background: #10b981;
-    animation: pulse-dot 2s ease-in-out infinite;
-  }
-  @keyframes pulse-dot {
-    0%, 100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
-    50% { box-shadow: 0 0 0 4px rgba(16, 185, 129, 0); }
+    background: var(--color-accent);
   }
 
-  .headline {
-    font-size: clamp(2.25rem, 7vw, 5rem);
-    font-weight: 700;
-    line-height: 1.05;
-    letter-spacing: var(--tracking-tighter);
-    margin-bottom: var(--space-4);
-    text-wrap: balance;
+  .hero .eyebrow {
+    margin-bottom: 1.15rem;
   }
-  .dim { color: var(--color-text-dim); font-weight: 500; }
 
-  .subtitle {
-    font-size: var(--text-base);
+  .hero h1 {
+    max-width: 11ch;
+    margin-bottom: 1.5rem;
+    font-size: clamp(3rem, 6vw, 5.4rem);
+    font-weight: 600;
+    line-height: 0.96;
+  }
+
+  .hero-summary {
+    max-width: 58ch;
+    margin-bottom: 2rem;
     color: var(--color-text-muted);
-    line-height: var(--leading-relaxed);
-    max-width: 52ch;
-    margin-bottom: var(--space-8);
-    text-wrap: balance;
-  }
-  @media (min-width: 768px) {
-    .subtitle { font-size: var(--text-lg); max-width: 60ch; }
+    font-size: clamp(1.05rem, 1.5vw, 1.2rem);
+    line-height: 1.65;
   }
 
-  /* ── Actions (centered) ── */
-  .actions {
+  .hero-actions,
+  .cta-actions {
     display: flex;
-    flex-direction: column;
-    gap: var(--space-3);
-    width: 100%;
-    max-width: 480px;
-    align-items: center;
-  }
-  @media (min-width: 640px) {
-    .actions {
-      flex-direction: row;
-      justify-content: center;
-      max-width: none;
-      gap: var(--space-3);
-    }
+    flex-wrap: wrap;
+    gap: 0.75rem;
   }
 
-  .install-box {
-    display: flex;
+  .button {
+    display: inline-flex;
+    min-height: 2.9rem;
     align-items: center;
-    gap: var(--space-3);
-    padding: 0 var(--space-4);
-    height: 2.75rem;
-    background: var(--color-bg-code);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    width: 100%;
-    box-sizing: border-box;
+    justify-content: center;
+    padding-inline: 1.1rem;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition:
+      color var(--transition-fast),
+      background var(--transition-fast),
+      border-color var(--transition-fast),
+      transform var(--transition-fast);
   }
-  @media (min-width: 640px) {
-    .install-box { width: auto; flex-shrink: 0; }
+
+  .button:active,
+  .install-command:active {
+    transform: translateY(1px);
   }
-  .install-box:hover {
+
+  .button-primary {
+    background: var(--color-accent);
+    color: var(--color-accent-ink);
+  }
+
+  .button-primary:hover {
+    background: var(--color-accent-hover);
+    color: var(--color-accent-ink);
+  }
+
+  .button-secondary {
+    border-color: var(--border-strong);
+    background: var(--color-bg-card);
+    color: var(--color-text);
+  }
+
+  .button-secondary:hover {
     border-color: var(--color-text-dim);
     background: var(--color-bg-elevated);
-    transform: translateY(-1px);
+    color: var(--color-text);
   }
-  .prompt { color: var(--color-text-dim); }
-  .cmd {
-    font-size: var(--text-sm);
+
+  .install-command {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: center;
+    width: min(100%, 28rem);
+    min-height: 3rem;
+    margin-top: 1rem;
+    padding: 0.65rem 0.85rem;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg-code);
     color: var(--color-text-secondary);
-    flex: 1;
+    cursor: pointer;
     text-align: left;
+    transition:
+      border-color var(--transition-fast),
+      transform var(--transition-fast);
+  }
+
+  .install-command:hover {
+    border-color: var(--border-strong);
+  }
+
+  .install-command code {
+    overflow: hidden;
+    color: inherit;
+    font-size: 0.8rem;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .copy-icon { color: var(--color-text-dim); display: flex; margin-left: auto; }
 
-  .btn-row {
-    display: flex;
-    gap: var(--space-3);
-    width: 100%;
-  }
-  @media (min-width: 640px) {
-    .btn-row { width: auto; }
-  }
-  .btn-row .btn {
-    flex: 1;
-    height: 2.75rem;
-  }
-  @media (min-width: 640px) {
-    .btn-row .btn { flex: none; }
-  }
-
-  /* ═══════════════════════════════
-     TERMINAL PREVIEW
-     ═══════════════════════════════ */
-  .terminal-section {
-    padding-bottom: var(--space-16);
-  }
-
-  .terminal {
-    background: #0c0c0e;
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-xl);
-    overflow: hidden;
-    box-shadow:
-      0 0 0 1px rgba(255, 255, 255, 0.03),
-      0 20px 60px rgba(0, 0, 0, 0.4),
-      0 0 80px rgba(16, 185, 129, 0.04);
-    max-width: 860px;
-    margin: 0 auto;
-  }
-  :root[data-theme='light'] .terminal {
-    box-shadow:
-      0 0 0 1px rgba(0, 0, 0, 0.06),
-      0 20px 60px rgba(0, 0, 0, 0.1);
-  }
-
-  .terminal-bar {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    padding: var(--space-3) var(--space-4);
-    background: rgba(255, 255, 255, 0.03);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  }
-  .terminal-dots {
-    display: flex;
-    gap: 6px;
-  }
-  .td {
-    width: 12px; height: 12px;
-    border-radius: 50%;
-    opacity: 0.8;
-  }
-  .terminal-title {
-    font-size: var(--text-xs);
-    color: #71717a;
-    margin-left: var(--space-2);
-  }
-
-  .terminal-body {
-    padding: var(--space-5) var(--space-6);
-    font-size: 12px;
-    line-height: 1.7;
-    color: #e4e4e7;
-    overflow-x: auto;
-    margin: 0;
-  }
-  .terminal-body code {
-    font-family: inherit;
-    font-size: inherit;
-    background: none;
-    border: none;
-    padding: 0;
-    color: inherit;
-  }
-  @media (min-width: 768px) {
-    .terminal-body { font-size: 13px; }
-  }
-
-  .t-dim { color: #52525b; }
-  .t-head { color: #71717a; font-weight: 600; }
-  .t-sep { color: #3f3f46; }
-  .t-date { color: #a1a1aa; }
-  .t-source { color: #10b981; }
-  .t-model { color: #a1a1aa; }
-  .t-num { color: #a1a1aa; }
-  .t-cost { color: #fafafa; font-weight: 500; }
-  .t-total { font-weight: 600; color: #fafafa; }
-  .t-cost-total { color: #10b981; font-weight: 700; }
-
-  /* ═══════════════════════════════
-     SPEED COMPARISON
-     ═══════════════════════════════ */
-  .speed-section {
-    padding-bottom: var(--space-16);
-  }
-
-  .speed-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--space-4);
-  }
-  @media (min-width: 640px) {
-    .speed-grid { grid-template-columns: repeat(3, 1fr); }
-  }
-
-  .speed-card {
-    text-align: center;
-    padding: var(--space-8) var(--space-6);
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-xl);
-    background: var(--color-bg-card);
-    transition: all var(--transition-base);
-  }
-  .speed-card:hover {
-    border-color: var(--border-strong);
-    transform: translateY(-4px);
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.15);
-  }
-
-  .speed-highlight {
-    border-color: var(--border-strong);
-    background: var(--color-bg-elevated);
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-  }
-
-  .speed-number {
-    font-size: clamp(2.5rem, 5vw, 4rem);
-    font-weight: 700;
-    letter-spacing: var(--tracking-tighter);
-    color: var(--color-text);
-    line-height: 1;
-    margin-bottom: var(--space-3);
-  }
-  .speed-x {
-    font-size: 0.5em;
-    color: var(--color-text-dim);
-    font-weight: 400;
-  }
-  .speed-label {
-    font-size: var(--text-sm);
-    color: var(--color-text-muted);
-    margin-bottom: var(--space-2);
-  }
-  .speed-detail {
-    font-size: var(--text-xs);
-    color: var(--color-text-dim);
-  }
-
-  /* ═══════════════════════════════
-     COMMANDS
-     ═══════════════════════════════ */
-  .commands-section {
-    padding-bottom: var(--space-16);
-  }
-
-  .cmd-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    align-items: start;
-    gap: var(--space-4);
-  }
-  @media (min-width: 640px) {
-    .cmd-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  }
-  @media (min-width: 768px) {
-    .cmd-grid { gap: var(--space-5); }
-  }
-  @media (min-width: 1200px) {
-    .cmd-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-  }
-
-  .cmd-card {
-    margin: 0;
-    padding: var(--space-6) var(--space-6) var(--space-5);
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-xl);
-    background: var(--color-bg-card);
-    display: flex;
-    flex-direction: column;
-    align-self: start;
-    transition: all var(--transition-base);
-  }
-  @media (min-width: 640px) {
-    .cmd-card { min-height: 22.5rem; }
-  }
-  .cmd-card:hover {
-    border-color: var(--border-strong);
-    transform: translateY(-4px);
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.15);
-  }
-
-  .cmd-icon {
-    font-size: 1.5rem;
-    margin-bottom: var(--space-4);
-    line-height: 1;
-  }
-  .cmd-name {
-    font-size: var(--text-lg);
-    font-weight: 600;
-    letter-spacing: var(--tracking-tight);
-    margin-bottom: var(--space-2);
-  }
-  .cmd-desc {
-    font-size: var(--text-sm);
-    color: var(--color-text-muted);
-    line-height: var(--leading-relaxed);
-    margin-bottom: auto;
-    padding-bottom: var(--space-5);
-  }
-  .cmd-code {
-    background: var(--color-bg-code);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: var(--space-3) var(--space-4);
-    font-size: 12px;
-    color: var(--color-text-secondary);
-    overflow-x: auto;
-    white-space: pre-wrap;
-    margin: 0;
-    min-height: 4.5rem;
-    display: flex;
-    align-items: center;
-  }
-
-  /* ═══════════════════════════════
-     SOURCES
-     ═══════════════════════════════ */
-  .sources-section {
-    padding-bottom: var(--space-16);
-  }
-
-  .source-strip {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: var(--space-3);
-  }
-
-  .source-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-2) var(--space-4);
+  .prompt {
+    color: var(--color-accent);
     font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    font-weight: 500;
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-full);
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: all var(--transition-fast);
-  }
-  .source-chip:hover {
-    border-color: var(--border-strong);
-    color: var(--color-text);
-    transform: translateY(-2px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
-  }
-  .source-dot {
-    width: 8px; height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
   }
 
-  /* ═══════════════════════════════
-     METRICS BAR
-     ═══════════════════════════════ */
-  .metrics-section {
-    padding-bottom: var(--space-12);
-  }
-
-  .metrics-bar {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    gap: var(--space-8);
-    padding: var(--space-8) var(--space-4);
-    border-top: 1px solid var(--border-subtle);
-    border-bottom: 1px solid var(--border-subtle);
-  }
-  @media (min-width: 640px) {
-    .metrics-bar { gap: var(--space-10); flex-wrap: nowrap; }
-  }
-
-  .metric { text-align: center; flex-shrink: 0; }
-  .metric-val {
-    font-size: var(--text-2xl);
-    font-weight: 600;
-    letter-spacing: var(--tracking-tighter);
-    color: var(--color-text);
-    line-height: 1;
-    margin-bottom: var(--space-1);
-  }
-  .metric-label {
-    font-size: var(--text-xs);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+  .copy-label {
     color: var(--color-text-dim);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
   }
 
-  .metric-sep {
-    width: 1px;
-    height: 2.5rem;
-    background: var(--border-default);
-    flex-shrink: 0;
-    display: none;
-  }
-  @media (min-width: 640px) {
-    .metric-sep { display: block; }
-  }
-
-  /* ═══════════════════════════════
-     FOOTER
-     ═══════════════════════════════ */
-  .footer {
-    padding-top: var(--space-10);
-    padding-bottom: var(--space-8);
-    border-top: 1px solid var(--border-subtle);
+  .report-preview {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg);
+    background: var(--color-bg-code);
+    box-shadow: 0 24px 60px -36px var(--shadow-elevated);
+    animation: enter 700ms 120ms var(--ease-out) both;
   }
 
-  .footer-top {
+  .report-preview::before {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 3px;
+    background: var(--color-accent);
+    content: '';
+  }
+
+  .preview-header,
+  .preview-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .preview-header {
+    padding: 1.25rem 1.4rem;
+    border-bottom: 1px solid var(--border-default);
+  }
+
+  .preview-header > div {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    gap: var(--space-5);
-    margin-bottom: var(--space-6);
+    gap: 0.2rem;
   }
-  @media (min-width: 640px) {
-    .footer-top {
-      flex-direction: row;
-      justify-content: space-between;
-    }
+
+  .preview-kicker {
+    color: var(--color-text-dim);
+    font-size: 0.62rem;
+  }
+
+  .preview-title {
+    color: var(--color-text);
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .preview-status {
+    padding: 0.3rem 0.5rem;
+    border: 1px solid color-mix(in srgb, var(--color-accent) 35%, transparent);
+    border-radius: var(--radius-sm);
+    color: var(--color-accent);
+    font-size: 0.6rem;
+  }
+
+  .preview-command {
+    padding: 1.25rem 1.4rem 1rem;
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+  }
+
+  .preview-command span {
+    color: var(--color-accent);
+  }
+
+  .preview-table {
+    padding-inline: 1.4rem;
+    font-family: var(--font-mono);
+    font-size: clamp(0.66rem, 1.15vw, 0.78rem);
+  }
+
+  .preview-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 0.9fr 0.75fr;
+    gap: 0.75rem;
+    align-items: center;
+    min-height: 3.25rem;
+    border-top: 1px solid var(--border-default);
+    color: var(--color-text-muted);
+  }
+
+  .preview-row span:nth-child(n + 3) {
+    text-align: right;
+  }
+
+  .preview-table-head {
+    min-height: 2.2rem;
+    border-top: 0;
+    color: var(--color-text-dim);
+    font-family: var(--font-sans);
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .preview-row .source-name {
+    color: var(--color-accent);
+  }
+
+  .preview-total {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+
+  .preview-foot {
+    padding: 1rem 1.4rem;
+    border-top: 1px solid var(--border-default);
+    color: var(--color-text-dim);
+    font-size: 0.65rem;
+  }
+
+  .preview-foot span:first-child {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .preview-foot i {
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 50%;
+    background: var(--color-accent);
+  }
+
+  .fact-strip {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    border-block: 1px solid var(--border-default);
+  }
+
+  .fact-strip > div {
+    display: flex;
+    min-height: 7rem;
+    flex-direction: column;
+    justify-content: center;
+    padding: 1.25rem;
+    border-right: 1px solid var(--border-default);
+  }
+
+  .fact-strip > div:first-child {
+    padding-left: 0;
+  }
+
+  .fact-strip > div:last-child {
+    border-right: 0;
+  }
+
+  .fact-strip strong {
+    color: var(--color-text);
+    font-family: var(--font-mono);
+    font-size: 1.3rem;
+    font-weight: 600;
+  }
+
+  .fact-strip span {
+    color: var(--color-text-dim);
+    font-size: 0.78rem;
+  }
+
+  .section-heading {
+    display: grid;
+    grid-template-columns: minmax(14rem, 0.7fr) minmax(20rem, 1.3fr);
+    column-gap: 4rem;
+    margin-bottom: 4.5rem;
+  }
+
+  .section-heading .eyebrow {
+    grid-row: 1 / span 2;
+  }
+
+  .section-heading h2,
+  .section-heading > p:last-child {
+    grid-column: 2;
+  }
+
+  .section-heading > p:last-child,
+  .sources-copy > p:not(.eyebrow),
+  .benchmark-copy > p:not(.eyebrow) {
+    max-width: 62ch;
+    margin-bottom: 0;
+    color: var(--color-text-muted);
+    font-size: 1.05rem;
+    line-height: 1.65;
+  }
+
+  .report-list {
+    border-top: 1px solid var(--border-strong);
+  }
+
+  .report-row {
+    display: grid;
+    grid-template-columns: 3rem minmax(12rem, 0.8fr) minmax(18rem, 1.2fr) minmax(12rem, auto);
+    gap: 1.5rem;
+    align-items: start;
+    padding-block: 1.75rem;
+    border-bottom: 1px solid var(--border-default);
+  }
+
+  .report-number {
+    padding-top: 0.2rem;
+    color: var(--color-accent);
+    font-size: 0.72rem;
+  }
+
+  .report-row h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  .report-row > p {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+    line-height: 1.6;
+  }
+
+  .command-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.4rem;
+  }
+
+  .command-list code {
+    padding: 0.35rem 0.5rem;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg-code);
+    color: var(--color-text-secondary);
+    font-size: 0.68rem;
+    white-space: nowrap;
+  }
+
+  .text-link {
+    display: inline-flex;
+    margin-top: 2rem;
+    color: var(--color-text);
+    font-size: 0.88rem;
+    font-weight: 600;
+    text-underline-offset: 0.3rem;
+  }
+
+  .text-link:hover {
+    color: var(--color-accent);
+  }
+
+  .sources {
+    display: grid;
+    grid-template-columns: minmax(20rem, 0.85fr) minmax(30rem, 1.15fr);
+    gap: clamp(4rem, 10vw, 9rem);
+    align-items: start;
+  }
+
+  .sources-copy {
+    position: sticky;
+    top: calc(var(--sl-nav-height) + 3rem);
+  }
+
+  .sources-copy .eyebrow,
+  .benchmark-copy .eyebrow {
+    margin-bottom: 1rem;
+  }
+
+  .sources-copy .text-link,
+  .benchmark-copy .text-link {
+    margin-top: 1.75rem;
+  }
+
+  .source-groups {
+    border-top: 1px solid var(--border-strong);
+  }
+
+  .source-group {
+    display: grid;
+    grid-template-columns: 5rem 1fr;
+    gap: 2rem;
+    padding-block: 2rem;
+    border-bottom: 1px solid var(--border-default);
+  }
+
+  .source-format {
+    padding-top: 0.25rem;
+    color: var(--color-accent);
+  }
+
+  .source-group ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .source-group li {
+    padding: 0.45rem 0.65rem;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg-card);
+    color: var(--color-text-secondary);
+    font-size: 0.8rem;
+  }
+
+  .pipeline-heading {
+    margin-bottom: 4rem;
+  }
+
+  .pipeline-layout {
+    display: grid;
+    grid-template-columns: minmax(20rem, 0.85fr) minmax(24rem, 1.15fr);
+    gap: clamp(3rem, 8vw, 7rem);
+  }
+
+  .pipeline-flow {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .pipeline-flow li {
+    position: relative;
+    display: grid;
+    grid-template-columns: 3rem 1fr;
+    gap: 1rem;
+    padding-bottom: 2rem;
+  }
+
+  .pipeline-flow li:not(:last-child)::before {
+    position: absolute;
+    top: 1.7rem;
+    bottom: 0.35rem;
+    left: 1rem;
+    width: 1px;
+    background: var(--border-strong);
+    content: '';
+  }
+
+  .flow-index {
+    position: relative;
+    display: grid;
+    width: 2rem;
+    height: 2rem;
+    place-items: center;
+    border: 1px solid var(--border-strong);
+    border-radius: 50%;
+    background: var(--color-bg);
+    color: var(--color-accent);
+    font-size: 0.62rem;
+  }
+
+  .pipeline-flow strong {
+    color: var(--color-text);
+    font-size: 1rem;
+  }
+
+  .pipeline-flow p {
+    margin: 0.35rem 0 0;
+    color: var(--color-text-muted);
+    font-size: 0.88rem;
+    line-height: 1.55;
+  }
+
+  .pipeline-notes {
+    display: grid;
+    gap: 1px;
+    overflow: hidden;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    background: var(--border-default);
+  }
+
+  .pipeline-notes article {
+    padding: clamp(2rem, 5vw, 3.25rem);
+    background: var(--color-bg-card);
+  }
+
+  .note-label {
+    color: var(--color-accent);
+  }
+
+  .pipeline-notes h3 {
+    max-width: 22ch;
+    margin: 1rem 0;
+    font-size: clamp(1.5rem, 3vw, 2.25rem);
+    font-weight: 600;
+    line-height: 1.05;
+  }
+
+  .pipeline-notes p {
+    max-width: 55ch;
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+    line-height: 1.65;
+  }
+
+  .pipeline-notes a {
+    color: var(--color-text);
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-underline-offset: 0.25rem;
+  }
+
+  .benchmark {
+    display: grid;
+    grid-template-columns: minmax(22rem, 0.9fr) minmax(26rem, 1.1fr);
+    gap: clamp(4rem, 10vw, 9rem);
+    align-items: start;
+  }
+
+  .benchmark-data {
+    margin: 0;
+    border-top: 1px solid var(--border-strong);
+  }
+
+  .benchmark-data > div {
+    display: grid;
+    grid-template-columns: minmax(10rem, 1fr) auto;
+    column-gap: 1.5rem;
+    padding-block: 1.5rem;
+    border-bottom: 1px solid var(--border-default);
+  }
+
+  .benchmark-data dt {
+    color: var(--color-text-muted);
+    font-size: 0.82rem;
+  }
+
+  .benchmark-data dd {
+    grid-row: 1 / span 2;
+    grid-column: 2;
+    margin: 0;
+    color: var(--color-text);
+    font-family: var(--font-mono);
+    font-size: clamp(1.5rem, 3vw, 2.5rem);
+    font-weight: 600;
+    letter-spacing: var(--tracking-tighter);
+  }
+
+  .benchmark-data span {
+    color: var(--color-text-dim);
+    font-size: 0.72rem;
+  }
+
+  .final-cta {
+    display: grid;
+    grid-template-columns: 1.4fr auto;
+    gap: 3rem;
+    align-items: end;
+  }
+
+  .final-cta .eyebrow {
+    margin-bottom: 1rem;
+  }
+
+  .final-cta h2 {
+    margin-bottom: 0;
+  }
+
+  .landing-footer {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 1.5rem 3rem;
+    align-items: center;
+    padding-block: 2.5rem;
+    border-top: 1px solid var(--border-default);
   }
 
   .footer-brand {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: var(--space-3);
+    gap: 0.75rem;
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-decoration: none;
   }
-  .footer-name {
-    font-size: var(--text-sm);
-    font-weight: 500;
+
+  .landing-footer nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+  }
+
+  .landing-footer nav a {
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    text-decoration: none;
+  }
+
+  .landing-footer nav a:hover {
     color: var(--color-text);
   }
 
-  .footer-nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: var(--space-6);
-  }
-  .footer-nav a {
-    font-size: var(--text-sm);
+  .landing-footer > p {
+    grid-column: 1 / -1;
+    margin: 0;
     color: var(--color-text-dim);
-    text-decoration: none;
-    transition: color var(--transition-fast);
+    font-size: 0.72rem;
   }
-  .footer-nav a:hover { color: var(--color-text); }
 
-  .footer-bottom {
-    text-align: center;
-    font-size: var(--text-xs);
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    clip-path: inset(50%);
   }
-  @media (min-width: 640px) {
-    .footer-bottom { text-align: left; }
+
+  @keyframes enter {
+    from {
+      opacity: 0;
+      transform: translateY(1rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (max-width: 980px) {
+    .hero,
+    .sources,
+    .pipeline-layout,
+    .benchmark {
+      grid-template-columns: 1fr;
+    }
+
+    .hero {
+      min-height: auto;
+    }
+
+    .hero h1 {
+      max-width: 13ch;
+    }
+
+    .report-preview {
+      max-width: 44rem;
+    }
+
+    .sources-copy {
+      position: static;
+    }
+
+    .report-row {
+      grid-template-columns: 2.5rem minmax(12rem, 0.8fr) minmax(18rem, 1.2fr);
+    }
+
+    .command-list {
+      grid-column: 2 / -1;
+      justify-content: flex-start;
+    }
+
+    .pipeline-layout,
+    .benchmark {
+      gap: 3rem;
+    }
+  }
+
+  @media (max-width: 720px) {
+    .landing,
+    .landing-footer {
+      padding-inline: 1.1rem;
+    }
+
+    .hero {
+      gap: 3rem;
+      padding-block: 3.5rem 4.5rem;
+    }
+
+    .release-link {
+      margin-bottom: 2.5rem;
+    }
+
+    .hero h1 {
+      font-size: clamp(2.75rem, 14vw, 4rem);
+    }
+
+    .hero-actions,
+    .cta-actions {
+      flex-direction: column;
+    }
+
+    .hero-actions .button,
+    .cta-actions .button {
+      width: 100%;
+    }
+
+    .preview-row {
+      grid-template-columns: 1fr 0.8fr 0.8fr;
+    }
+
+    .preview-row span:nth-child(2) {
+      display: none;
+    }
+
+    .fact-strip {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    .fact-strip > div {
+      min-height: 6rem;
+      padding: 1rem;
+      border-bottom: 1px solid var(--border-default);
+    }
+
+    .fact-strip > div:first-child {
+      padding-left: 1rem;
+    }
+
+    .fact-strip > div:nth-child(2) {
+      border-right: 0;
+    }
+
+    .fact-strip > div:nth-child(n + 3) {
+      border-bottom: 0;
+    }
+
+    .section-heading {
+      display: block;
+      margin-bottom: 3rem;
+    }
+
+    .section-heading .eyebrow {
+      margin-bottom: 1rem;
+    }
+
+    .report-row {
+      grid-template-columns: 2rem 1fr;
+      gap: 0.75rem 1rem;
+    }
+
+    .report-row > p,
+    .command-list {
+      grid-column: 2;
+    }
+
+    .sources {
+      gap: 3rem;
+    }
+
+    .source-group {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+
+    .final-cta,
+    .landing-footer {
+      grid-template-columns: 1fr;
+      align-items: start;
+    }
+
+    .landing-footer nav,
+    .landing-footer > p {
+      grid-column: 1;
+    }
   }
 </style>

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -1,38 +1,33 @@
 /** @format */
 
-/* Custom styles for llm-usage-metrics site */
-
-/* ── Base Styles ─────────────────────────────────────────── */
 html {
   scroll-behavior: smooth;
-  background-color: var(--color-bg);
+  background: var(--color-bg);
   color: var(--color-text);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  html {
-    scroll-behavior: auto;
-  }
+body {
+  font-family: var(--font-sans);
+  background: var(--color-bg);
 }
 
 ::selection {
-  background: var(--color-text-dim);
-  color: var(--color-bg);
+  background: var(--color-accent-subtle);
+  color: var(--color-text);
 }
 
 :focus-visible {
   outline: 2px solid var(--border-focus);
-  outline-offset: 2px;
+  outline-offset: 3px;
 }
 
 :focus:not(:focus-visible) {
   outline: none;
 }
 
-/* ── Scrollbar ──────────────────────────────────────────── */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 7px;
+  height: 7px;
 }
 
 ::-webkit-scrollbar-track {
@@ -40,8 +35,8 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border-strong);
   border-radius: var(--radius-full);
+  background: var(--border-strong);
 }
 
 ::-webkit-scrollbar-thumb:hover {
@@ -49,11 +44,10 @@ html {
 }
 
 * {
-  scrollbar-width: thin;
   scrollbar-color: var(--border-strong) var(--color-bg);
+  scrollbar-width: thin;
 }
 
-/* ── Typography Utilities ───────────────────────────────── */
 .text-balance {
   text-wrap: balance;
 }
@@ -70,131 +64,184 @@ html {
   letter-spacing: var(--tracking-tighter);
 }
 
-/* ── Interactive States ─────────────────────────────────── */
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-2);
-  padding: 0 var(--space-4);
-  height: 2.5rem;
-  box-sizing: border-box;
-  font-family: var(--font-sans);
-  font-size: var(--text-sm);
-  font-weight: 500;
-  border-radius: var(--radius-sm);
-  transition: all var(--transition-fast);
-  cursor: pointer;
-  text-decoration: none;
-}
-
-.btn:active {
-  transform: scale(0.98);
-}
-
-.btn-primary {
-  background: var(--color-text);
-  color: var(--color-bg);
-  border: 1px solid var(--color-text);
-}
-
-.btn-primary:hover {
-  background: transparent;
-  color: var(--color-text);
-}
-
-.btn-secondary {
-  background: transparent;
-  color: var(--color-text);
-  border: 1px solid var(--border-strong);
-}
-
-.btn-secondary:hover {
-  background: var(--color-bg-elevated);
-  border-color: var(--color-text-dim);
-}
-
-/* ── Code Blocks ─────────────────────────────────────────── */
-code {
+code,
+pre {
   font-family: var(--font-mono);
 }
 
 :not(pre) > code {
-  padding: 0.1em 0.3em;
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--border-subtle);
-  border-radius: 0.2rem;
-  font-size: 0.9em;
-  color: var(--color-text-secondary);
-}
-
-/* ── Layout & Bento Containers ──────────────────────────── */
-.bento-card {
-  background: var(--color-bg);
+  padding: 0.12em 0.34em;
   border: 1px solid var(--border-default);
-  padding: var(--space-6);
+  border-radius: 0.25rem;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-secondary);
+  font-size: 0.9em;
 }
 
-/* ── Starlight Overrides ────────────────────────────────── */
 :root {
+  --sl-font: var(--font-sans);
+  --sl-font-mono: var(--font-mono);
   --sl-color-white: var(--color-text);
   --sl-color-gray-1: var(--color-text-secondary);
   --sl-color-gray-2: var(--color-text-muted);
-  --sl-color-gray-3: var(--border-strong);
-  --sl-color-gray-4: var(--border-default);
-  --sl-color-gray-5: var(--border-subtle);
+  --sl-color-gray-3: var(--color-text-dim);
+  --sl-color-gray-4: var(--border-strong);
+  --sl-color-gray-5: var(--border-default);
   --sl-color-gray-6: var(--color-bg-elevated);
   --sl-color-black: var(--color-bg);
-  --sl-color-accent: var(--color-text);
-  --sl-color-accent-high: var(--color-text);
-  --sl-color-bg-nav: var(--color-bg);
+  --sl-color-accent-low: var(--color-accent-subtle);
+  --sl-color-accent: var(--color-accent);
+  --sl-color-accent-high: var(--color-accent-hover);
+  --sl-color-bg: var(--color-bg);
+  --sl-color-bg-nav: color-mix(in srgb, var(--color-bg) 92%, transparent);
+  --sl-color-bg-sidebar: var(--color-bg);
+  --sl-content-width: 52rem;
 }
 
-/* Simplify the header to be incredibly flat */
-.starlight-header {
-  background: var(--color-bg) !important;
-  border-bottom: 1px solid var(--border-default) !important;
-  backdrop-filter: none;
+header.header {
+  border-bottom: 1px solid var(--border-default);
+  background: color-mix(in srgb, var(--color-bg) 90%, transparent);
+  box-shadow: inset 0 -1px 0 var(--border-subtle);
+  backdrop-filter: blur(16px);
 }
 
-/* Theme toggle button override */
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  border: 1px solid transparent;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-}
-
-.theme-toggle:hover {
-  background: var(--color-bg-elevated);
+.site-title {
+  gap: 0.7rem;
   color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
 }
 
-@media (pointer: coarse) {
-  .theme-toggle {
-    width: 44px;
-    height: 44px;
-  }
+.site-title img {
+  width: 1.75rem;
+  height: 1.75rem;
+}
 
-  .btn,
-  a {
-    min-height: 44px;
-    min-width: 44px;
+.sidebar-pane {
+  border-right-color: var(--border-default);
+  background: var(--color-bg);
+}
+
+.sidebar-content a {
+  border-radius: var(--radius-sm);
+}
+
+.sidebar-content a[aria-current='page'] {
+  background: var(--color-accent-subtle);
+  color: var(--color-accent-hover);
+  font-weight: 600;
+}
+
+.right-sidebar {
+  border-left-color: var(--border-default);
+}
+
+.content-panel + .content-panel {
+  border-top-color: var(--border-default);
+}
+
+.sl-markdown-content {
+  color: var(--color-text-secondary);
+  font-size: 1rem;
+  line-height: 1.72;
+}
+
+.sl-markdown-content h1,
+.sl-markdown-content h2,
+.sl-markdown-content h3 {
+  color: var(--color-text);
+  letter-spacing: var(--tracking-tight);
+}
+
+.sl-markdown-content h1 {
+  font-size: clamp(2.25rem, 6vw, 3.6rem);
+  font-weight: 650;
+  line-height: 1.02;
+  letter-spacing: var(--tracking-tighter);
+}
+
+.sl-markdown-content h2 {
+  padding-top: 1rem;
+  font-size: 1.65rem;
+  font-weight: 620;
+}
+
+.sl-markdown-content h3 {
+  font-size: 1.15rem;
+  font-weight: 620;
+}
+
+.sl-markdown-content a:not([class]) {
+  color: var(--color-accent-hover);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+}
+
+.sl-markdown-content table {
+  display: table;
+  width: 100%;
+  font-size: 0.88rem;
+}
+
+.sl-markdown-content th {
+  color: var(--color-text);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.sl-markdown-content th,
+.sl-markdown-content td {
+  border-color: var(--border-default);
+}
+
+.sl-markdown-content tbody tr:nth-child(2n) {
+  background: var(--border-subtle);
+}
+
+.sl-markdown-content blockquote {
+  border-inline-start-color: var(--color-accent);
+  color: var(--color-text-muted);
+}
+
+.card {
+  border-color: var(--border-default) !important;
+  border-radius: var(--radius-md) !important;
+  background: var(--color-bg-card) !important;
+  box-shadow: none !important;
+  transition:
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.card:hover {
+  border-color: var(--border-strong) !important;
+  transform: translateY(-2px);
+}
+
+.pagination-links a {
+  border-color: var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-card);
+}
+
+.pagination-links a:hover {
+  border-color: var(--border-strong);
+}
+
+@media (max-width: 50rem) {
+  .sl-markdown-content table {
+    display: block;
   }
 }
 
 @media print {
   * {
     background: transparent !important;
-    color: black !important;
     box-shadow: none !important;
+    color: #181a16 !important;
     text-shadow: none !important;
   }
 }

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -1,93 +1,71 @@
 /** @format */
 
-/* ═══════════════════════════════════════════════════════════
-   Design Tokens - llm-usage-metrics
-   Light & Dark Theme Variables
-   ═══════════════════════════════════════════════════════════ */
-
-/* ── Dark Theme (Default) ───────────────────────────────── */
 :root {
-  /* Surfaces */
-  --color-bg: #09090b; /* Zinc 950 */
-  --color-bg-elevated: #18181b; /* Zinc 900 */
-  --color-bg-card: #09090b; /* Zinc 950 */
-  --color-bg-code: #18181b; /* Zinc 900 */
+  --color-bg: #11130f;
+  --color-bg-elevated: #191c17;
+  --color-bg-card: #151713;
+  --color-bg-code: #0d0f0c;
 
-  /* Text - High contrast for readability */
-  --color-text: #fafafa; /* Zinc 50 */
-  --color-text-secondary: #e4e4e7; /* Zinc 200 */
-  --color-text-muted: #a1a1aa; /* Zinc 400 */
-  --color-text-dim: #71717a; /* Zinc 500 */
+  --color-text: #f1f0e9;
+  --color-text-secondary: #d8d8d0;
+  --color-text-muted: #a1a49a;
+  --color-text-dim: #74786d;
 
-  /* Accent - Minimalist Monochrome */
-  --color-accent: #ffffff;
-  --color-accent-hover: #e4e4e7;
-  --color-accent-glow: rgba(255, 255, 255, 0.05);
-  --color-accent-subtle: rgba(255, 255, 255, 0.1);
+  --color-accent: #df7b52;
+  --color-accent-hover: #eb8c65;
+  --color-accent-ink: #24130d;
+  --color-accent-subtle: rgba(223, 123, 82, 0.12);
 
-  /* Utility */
-  --color-cyan: #38bdf8;
-  --color-yellow: #fbbf24;
-  --color-red: #f87171;
+  --color-cyan: #65aeb8;
+  --color-yellow: #d8ae66;
+  --color-red: #d86f69;
 
-  /* Borders */
-  --border-subtle: rgba(255, 255, 255, 0.04);
-  --border-default: rgba(255, 255, 255, 0.08);
-  --border-strong: rgba(255, 255, 255, 0.15);
-  --border-focus: rgba(255, 255, 255, 0.4);
+  --border-subtle: rgba(241, 240, 233, 0.045);
+  --border-default: rgba(241, 240, 233, 0.09);
+  --border-strong: rgba(241, 240, 233, 0.18);
+  --border-focus: #df7b52;
 
-  /* Shadows */
-  --shadow-color: rgba(0, 0, 0, 0.5);
-  --shadow-elevated: rgba(0, 0, 0, 0.55);
+  --shadow-color: rgba(5, 7, 4, 0.45);
+  --shadow-elevated: rgba(5, 7, 4, 0.72);
 }
 
-/* ── Light Theme ────────────────────────────────────────── */
 :root[data-theme='light'] {
-  /* Surfaces */
-  --color-bg: #ffffff;
-  --color-bg-elevated: #fafafa;
-  --color-bg-card: #ffffff;
-  --color-bg-code: #f4f4f5; /* Zinc 100 */
+  --color-bg: #f5f2ea;
+  --color-bg-elevated: #ece8de;
+  --color-bg-card: #fbf9f4;
+  --color-bg-code: #e9e5db;
 
-  /* Text */
-  --color-text: #09090b; /* Zinc 950 */
-  --color-text-secondary: #27272a; /* Zinc 800 */
-  --color-text-muted: #52525b; /* Zinc 600 */
-  --color-text-dim: #a1a1aa; /* Zinc 400 */
+  --color-text: #20231d;
+  --color-text-secondary: #343830;
+  --color-text-muted: #5f655b;
+  --color-text-dim: #858b80;
 
-  /* Accent - Dark Minimalist */
-  --color-accent: #000000;
-  --color-accent-hover: #27272a;
-  --color-accent-glow: rgba(0, 0, 0, 0.05);
-  --color-accent-subtle: rgba(0, 0, 0, 0.05);
+  --color-accent: #b65331;
+  --color-accent-hover: #9e4528;
+  --color-accent-ink: #fff8f2;
+  --color-accent-subtle: rgba(182, 83, 49, 0.1);
 
-  /* Utility */
-  --color-cyan: #0284c7;
-  --color-yellow: #d97706;
-  --color-red: #dc2626;
+  --color-cyan: #377f89;
+  --color-yellow: #986f2c;
+  --color-red: #a84440;
 
-  /* Borders */
-  --border-subtle: rgba(0, 0, 0, 0.04);
-  --border-default: rgba(0, 0, 0, 0.08);
-  --border-strong: rgba(0, 0, 0, 0.15);
-  --border-focus: rgba(0, 0, 0, 0.4);
+  --border-subtle: rgba(32, 35, 29, 0.05);
+  --border-default: rgba(32, 35, 29, 0.11);
+  --border-strong: rgba(32, 35, 29, 0.2);
+  --border-focus: #b65331;
 
-  /* Shadows */
-  --shadow-color: rgba(0, 0, 0, 0.03);
-  --shadow-elevated: rgba(0, 0, 0, 0.06);
+  --shadow-color: rgba(43, 36, 27, 0.06);
+  --shadow-elevated: rgba(43, 36, 27, 0.14);
 }
 
-/* ── Shared Tokens ──────────────────────────────────────── */
 :root {
-  /* Radii */
-  --radius-sm: 0.25rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
-  --radius-xl: 1rem;
+  --radius-sm: 0.35rem;
+  --radius-md: 0.55rem;
+  --radius-lg: 0.85rem;
+  --radius-xl: 1.1rem;
   --radius-2xl: 1.5rem;
   --radius-full: 9999px;
 
-  /* Spacing */
   --space-1: 0.25rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;
@@ -101,12 +79,10 @@
   --space-20: 5rem;
   --space-24: 6rem;
 
-  /* Typography */
   --font-sans:
     'Geist', -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Helvetica', 'Arial', sans-serif;
   --font-mono: 'Geist Mono', 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace;
 
-  /* Font Sizes */
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;
   --text-base: 1rem;
@@ -118,30 +94,25 @@
   --text-5xl: 3rem;
   --text-6xl: 3.75rem;
 
-  /* Line Heights */
   --leading-none: 1;
   --leading-tight: 1.15;
   --leading-snug: 1.3;
   --leading-normal: 1.5;
   --leading-relaxed: 1.625;
 
-  /* Letter Spacing */
   --tracking-tighter: -0.04em;
   --tracking-tight: -0.02em;
   --tracking-normal: 0;
   --tracking-wide: 0.01em;
 
-  /* Layout */
-  --max-w-container: 1200px;
+  --max-w-container: 1240px;
   --max-w-prose: 65ch;
 
-  /* Transitions */
-  --transition-fast: 150ms cubic-bezier(0.16, 1, 0.3, 1);
-  --transition-base: 250ms cubic-bezier(0.16, 1, 0.3, 1);
-  --transition-slow: 400ms cubic-bezier(0.16, 1, 0.3, 1);
-  --transition-spring: 500ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --transition-fast: 150ms var(--ease-out);
+  --transition-base: 250ms var(--ease-out);
+  --transition-slow: 400ms var(--ease-out);
 
-  /* Z-Index */
   --z-base: 0;
   --z-dropdown: 10;
   --z-sticky: 20;
@@ -156,9 +127,9 @@
   *,
   *::before,
   *::after {
+    scroll-behavior: auto !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
   }
 }

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -23,7 +23,7 @@
   --border-subtle: rgba(241, 240, 233, 0.045);
   --border-default: rgba(241, 240, 233, 0.09);
   --border-strong: rgba(241, 240, 233, 0.18);
-  --border-focus: #df7b52;
+  --border-focus: var(--color-accent);
 
   --shadow-color: rgba(5, 7, 4, 0.45);
   --shadow-elevated: rgba(5, 7, 4, 0.72);
@@ -52,7 +52,7 @@
   --border-subtle: rgba(32, 35, 29, 0.05);
   --border-default: rgba(32, 35, 29, 0.11);
   --border-strong: rgba(32, 35, 29, 0.2);
-  --border-focus: #b65331;
+  --border-focus: var(--color-accent);
 
   --shadow-color: rgba(43, 36, 27, 0.06);
   --shadow-elevated: rgba(43, 36, 27, 0.14);

--- a/src/cli/run-doctor-report.ts
+++ b/src/cli/run-doctor-report.ts
@@ -8,7 +8,12 @@ import {
   type EventStoreStoredFile,
   type EventStoreSummary,
 } from '../persistence/event-store.js';
-import { createDefaultAdapters, getDefaultSourceIds } from '../sources/create-default-adapters.js';
+import {
+  createDefaultAdapters,
+  getDefaultSourceIds,
+  getSourceStorageFormat,
+  type SourceStorageFormat,
+} from '../sources/create-default-adapters.js';
 import type { SourceAdapter } from '../sources/source-adapter.js';
 import { logger } from '../utils/logger.js';
 import { normalizeSourceFilter, validateSourceFilterValues } from './build-usage-data-inputs.js';
@@ -18,6 +23,7 @@ import type { DoctorCommandOptions } from './usage-data-contracts.js';
 
 export type DoctorSourceResult = {
   id: string;
+  format: SourceStorageFormat;
   status: 'ok' | 'error';
   itemsFound?: number;
   detail?: string;
@@ -68,17 +74,21 @@ export async function buildDoctorResults(
   const discoveredFilesBySource: DiscoveredFilesBySource = new Map();
 
   for (const adapter of adapters) {
+    const format = getSourceStorageFormat(adapter.id.toLowerCase());
+
     try {
       const files = await adapter.discoverFiles();
       discoveredFilesBySource.set(adapter.id.toLowerCase(), new Set(files));
       results.push({
         id: adapter.id,
+        format,
         status: 'ok',
         itemsFound: files.length,
       });
     } catch (error) {
       results.push({
         id: adapter.id,
+        format,
         status: 'error',
         error: getErrorReason(error),
       });
@@ -158,6 +168,7 @@ async function buildEventStoreDoctorResult(
     if (isMissingPathError(error)) {
       return {
         id: 'event-store',
+        format: 'sqlite',
         status: 'ok',
         itemsFound: 0,
         detail: 'not yet created',
@@ -166,6 +177,7 @@ async function buildEventStoreDoctorResult(
 
     return {
       id: 'event-store',
+      format: 'sqlite',
       status: 'error',
       error: getErrorReason(error),
     };
@@ -181,6 +193,7 @@ async function buildEventStoreDoctorResult(
     if (!isSupportedStoreSchemaVersion(summary.schemaVersion)) {
       return {
         id: 'event-store',
+        format: 'sqlite',
         status: 'error',
         error: getUnsupportedSchemaError(summary.schemaVersion),
       };
@@ -191,6 +204,7 @@ async function buildEventStoreDoctorResult(
 
     return {
       id: 'event-store',
+      format: 'sqlite',
       status: 'ok',
       itemsFound: summary.eventCount,
       detail: [
@@ -203,22 +217,25 @@ async function buildEventStoreDoctorResult(
   } catch (error) {
     return {
       id: 'event-store',
+      format: 'sqlite',
       status: 'error',
       error: getErrorReason(error),
     };
   }
 }
 
+const doctorStatusGlyphs = { ok: '✔', error: '✖' } as const;
+
 function renderDoctorText(results: DoctorSourceResult[]): string {
   const idWidth = Math.max(...results.map((result) => result.id.length), 0);
-  const statusWidth = 5;
+  const formatWidth = Math.max(...results.map((result) => result.format.length), 0);
   const lines = results.map((result) => {
     const detail =
       result.status === 'ok'
         ? (result.detail ?? `${result.itemsFound ?? 0} file(s)`)
         : (result.error ?? 'Unknown');
 
-    return `${result.id.padEnd(idWidth)}  ${result.status.padEnd(statusWidth)}  ${detail}`;
+    return `${doctorStatusGlyphs[result.status]} ${result.id.padEnd(idWidth)}  ${result.format.padEnd(formatWidth)}  ${detail}`;
   });
   const sourceResults = results.filter((result) => result.id !== 'event-store');
   const healthyCount = sourceResults.filter((result) => result.status === 'ok').length;

--- a/src/render/render-efficiency-share-svg.ts
+++ b/src/render/render-efficiency-share-svg.ts
@@ -11,17 +11,25 @@ import {
   formatInteger,
   formatUsd,
   renderShareAccentBar,
+  renderShareAccentGradientDef,
+  renderShareCommandBadge,
   renderShareFooter,
   scaleY,
-  SHARE_SVG_FOOTER_HEIGHT,
   SHARE_SVG_WIDTH,
   shareTheme,
   type Point,
 } from './share-svg-theme.js';
 
 const W = SHARE_SVG_WIDTH;
-const H = 640;
-const pad = { top: 160, right: 130, bottom: 70 + SHARE_SVG_FOOTER_HEIGHT, left: 110 };
+const H = 720;
+const left = 120;
+const right = 80;
+
+// Two stacked panels with their own scales replace the old dual-axis chart:
+// $/Commit reads as a line on top, commits as bars below, sharing the months.
+const usdPanel = { top: 190, bottom: 420 };
+const commitPanel = { top: 480, bottom: 610 };
+const monthLabelY = 640;
 
 const chartColors = {
   commits: '#8b949e',
@@ -44,113 +52,65 @@ function toAllRow(rows: EfficiencyRow[]): EfficiencyGrandTotalRow | undefined {
   return rows.find(isGrandTotalRow);
 }
 
-function renderSummaryStats(allRow: EfficiencyGrandTotalRow | undefined, vcenter: number): string {
-  const cost = formatUsd(allRow?.costUsd);
-  const commits = formatInteger(allRow?.commitCount ?? 0);
-  const usdPerCommit = formatUsd(allRow?.usdPerCommit);
-  const tokPerCommit = formatDecimal(allRow?.tokensPerCommit);
-
-  const y = vcenter;
+function renderSummaryStats(allRow: EfficiencyGrandTotalRow | undefined): string {
   const items = [
-    { label: 'Total Cost', value: cost, x: pad.left },
-    { label: 'Commits', value: commits, x: 280 },
-    { label: '$/Commit', value: usdPerCommit, x: 480 },
-    { label: 'Tokens/Commit', value: tokPerCommit, x: 680 },
+    { label: 'Total Cost', value: formatUsd(allRow?.costUsd), x: left },
+    { label: 'Commits', value: formatInteger(allRow?.commitCount ?? 0), x: left + 240 },
+    { label: '$/Commit', value: formatUsd(allRow?.usdPerCommit), x: left + 480 },
+    { label: 'Tokens/Commit', value: formatDecimal(allRow?.tokensPerCommit), x: left + 720 },
   ];
 
   return items
     .map(
       (item) =>
-        `<text x="${item.x}" y="${y}" font-size="14" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(item.label)}</text>` +
-        `<text x="${item.x}" y="${y + 20}" font-size="18" font-weight="700" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">${escapeSvg(item.value)}</text>`,
+        `<text x="${item.x}" y="96" font-size="13" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(item.label)}</text>` +
+        `<text x="${item.x}" y="122" font-size="22" font-weight="700" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">${escapeSvg(item.value)}</text>`,
     )
     .join('\n');
 }
 
-function renderLegend(x: number, y: number): string {
-  const items = [
-    { label: 'Commits', color: chartColors.commits, shape: 'rect' as const },
-    { label: '$ / Commit', color: chartColors.usdPerCommit, shape: 'line' as const },
-  ];
-
-  return items
-    .map((item, i) => {
-      const ix = x + i * 180;
-      const shape =
-        item.shape === 'rect'
-          ? `<rect x="${ix}" y="${y - 6}" width="14" height="14" rx="3" fill="${item.color}" opacity="0.5"/>`
-          : `<line x1="${ix}" y1="${y + 1}" x2="${ix + 14}" y2="${y + 1}" stroke="${item.color}" stroke-width="3" stroke-linecap="round"/>`;
-      return `${shape}<text x="${ix + 20}" y="${y + 5}" font-size="13" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">${escapeSvg(item.label)}</text>`;
-    })
-    .join('\n');
+function renderPanelFrame(panel: { top: number; bottom: number }): string {
+  return `<line x1="${left}" y1="${panel.bottom}" x2="${W - right}" y2="${panel.bottom}" stroke="${shareTheme.gridLine}" stroke-width="1"/>`;
 }
 
-function renderCommitBarLabels(
-  monthlyRows: EfficiencyPeriodRow[],
-  chartLeft: number,
-  stepX: number,
-  maxCommits: number,
-  chartTop: number,
-  chartBottom: number,
+function renderPanelLabel(
+  panel: { top: number; bottom: number },
+  label: string,
+  color: string,
+  maxLabel: string,
 ): string {
-  return monthlyRows
-    .map((row, i) => {
-      const x = chartLeft + i * stepX;
-      const yTop = scaleY(row.commitCount, maxCommits, chartTop, chartBottom);
-      return `<text x="${x.toFixed(2)}" y="${(yTop - 8).toFixed(0)}" text-anchor="middle" font-size="12" font-weight="600" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">${escapeSvg(formatInteger(row.commitCount))}</text>`;
-    })
-    .join('\n');
-}
-
-function renderUsdDataLabels(monthlyRows: EfficiencyPeriodRow[], usdPoints: Point[]): string {
-  return monthlyRows
-    .map((row, i) => {
-      const p = usdPoints[i];
-      const val = row.usdPerCommit;
-      if (val === undefined) return '';
-      const labelY = p.y - 14;
-      return `<text x="${p.x.toFixed(2)}" y="${labelY.toFixed(0)}" text-anchor="middle" font-size="12" font-weight="600" fill="${chartColors.usdPerCommit}" font-family="${shareTheme.font}">${escapeSvg(formatUsd(val))}</text>`;
-    })
-    .join('\n');
+  return [
+    `<text x="${left}" y="${panel.top - 14}" font-size="13" font-weight="600" fill="${color}" font-family="${shareTheme.font}">${escapeSvg(label)}</text>`,
+    `<text x="${W - right}" y="${panel.top - 14}" text-anchor="end" font-size="11" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">max ${escapeSvg(maxLabel)}</text>`,
+  ].join('\n');
 }
 
 export function renderEfficiencyMonthlyShareSvg(efficiencyData: EfficiencyDataResult): string {
   const monthlyRows = toMonthlyRows(efficiencyData.rows);
   const allRow = toAllRow(efficiencyData.rows);
 
-  const chartLeft = pad.left;
-  const chartTop = pad.top;
-  const chartRight = W - pad.right;
-  const chartBottom = H - pad.bottom;
-  const chartW = chartRight - chartLeft;
-
+  const chartW = W - left - right;
   const count = Math.max(1, monthlyRows.length);
   const stepX = count === 1 ? 0 : chartW / (count - 1);
+  const toX = (index: number): number => (count === 1 ? left + chartW / 2 : left + index * stepX);
 
   const maxCommits = Math.max(1, ...monthlyRows.map((r) => r.commitCount));
   const actualMaxUsd = Math.max(0, ...monthlyRows.map((r) => Math.max(0, r.usdPerCommit ?? 0)));
-  const scaleMaxUsd = Math.max(0.01, actualMaxUsd);
-
-  const barWidth = Math.min(48, Math.max(18, chartW / (count * 2.2)));
-
-  const commitBars = monthlyRows
-    .map((row, i) => {
-      const x = chartLeft + i * stepX;
-      const yTop = scaleY(row.commitCount, maxCommits, chartTop, chartBottom);
-      return `<rect x="${(x - barWidth / 2).toFixed(2)}" y="${yTop.toFixed(2)}" width="${barWidth.toFixed(2)}" height="${(chartBottom - yTop).toFixed(2)}" rx="4" fill="${chartColors.commits}" fill-opacity="0.35"/>`;
-    })
-    .join('\n');
+  const scaleMaxUsd = Math.max(0.01, actualMaxUsd) * 1.08;
 
   const usdPoints: Point[] = monthlyRows.map((row, i) => ({
-    x: chartLeft + i * stepX,
-    y: scaleY(row.usdPerCommit ?? 0, scaleMaxUsd, chartTop, chartBottom),
+    x: toX(i),
+    y: scaleY(row.usdPerCommit ?? 0, scaleMaxUsd, usdPanel.top, usdPanel.bottom),
   }));
 
+  const usdArea =
+    usdPoints.length >= 2
+      ? `<path d="${catmullRom(usdPoints, 0.3, usdPanel.bottom)} L${usdPoints[usdPoints.length - 1].x.toFixed(2)},${usdPanel.bottom} L${usdPoints[0].x.toFixed(2)},${usdPanel.bottom} Z" fill="url(#usd-area-grad)"/>`
+      : '';
   const usdLine =
     usdPoints.length >= 2
-      ? `<path d="${catmullRom(usdPoints, 0.3, chartBottom)}" fill="none" stroke="${chartColors.usdPerCommit}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>`
+      ? `<path d="${catmullRom(usdPoints, 0.3, usdPanel.bottom)}" fill="none" stroke="${chartColors.usdPerCommit}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>`
       : '';
-
   const dotRadius = count <= 4 ? 6 : 4.5;
   const usdDots = usdPoints
     .map(
@@ -158,57 +118,67 @@ export function renderEfficiencyMonthlyShareSvg(efficiencyData: EfficiencyDataRe
         `<circle cx="${p.x.toFixed(2)}" cy="${p.y.toFixed(2)}" r="${dotRadius}" fill="${chartColors.usdPerCommit}"/>`,
     )
     .join('\n');
-
-  const monthLabels = monthlyRows
+  const usdLabels = monthlyRows
     .map((row, i) => {
-      const x = chartLeft + i * stepX;
-      return `<text x="${x.toFixed(2)}" y="${(chartBottom + 28).toFixed(0)}" text-anchor="middle" font-size="13" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(row.periodKey)}</text>`;
+      const val = row.usdPerCommit;
+      if (val === undefined) return '';
+      const p = usdPoints[i];
+      return `<text x="${p.x.toFixed(2)}" y="${(p.y - 14).toFixed(0)}" text-anchor="middle" font-size="12" font-weight="600" fill="${chartColors.usdPerCommit}" font-family="${shareTheme.font}">${escapeSvg(formatUsd(val))}</text>`;
     })
     .join('\n');
 
-  // Dual-axis labels: "Commits" on left, "$/Commit" on right
-  const axisLabels = [
-    `<text x="${(chartLeft - 12).toFixed(0)}" y="${(chartTop - 10).toFixed(0)}" text-anchor="end" font-size="12" font-weight="600" fill="${chartColors.commits}" font-family="${shareTheme.font}">Commits</text>`,
-    `<text x="${(chartLeft - 12).toFixed(0)}" y="${(chartTop + 5).toFixed(0)}" text-anchor="end" font-size="11" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(formatInteger(maxCommits))}</text>`,
-    `<text x="${(chartLeft - 12).toFixed(0)}" y="${(chartBottom + 5).toFixed(0)}" text-anchor="end" font-size="11" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">0</text>`,
-    `<text x="${(chartRight + 12).toFixed(0)}" y="${(chartTop - 10).toFixed(0)}" font-size="12" font-weight="600" fill="${chartColors.usdPerCommit}" font-family="${shareTheme.font}">$/Commit</text>`,
-    `<text x="${(chartRight + 12).toFixed(0)}" y="${(chartTop + 5).toFixed(0)}" font-size="11" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(formatUsd(actualMaxUsd))}</text>`,
-    `<text x="${(chartRight + 12).toFixed(0)}" y="${(chartBottom + 5).toFixed(0)}" font-size="11" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">$0.00</text>`,
-  ].join('\n');
+  const barWidth = Math.min(48, Math.max(18, chartW / (count * 2.2)));
+  const commitBars = monthlyRows
+    .map((row, i) => {
+      const x = toX(i);
+      const yTop = scaleY(row.commitCount, maxCommits * 1.08, commitPanel.top, commitPanel.bottom);
+      return `<rect x="${(x - barWidth / 2).toFixed(2)}" y="${yTop.toFixed(2)}" width="${barWidth.toFixed(2)}" height="${(commitPanel.bottom - yTop).toFixed(2)}" rx="4" fill="${chartColors.commits}" fill-opacity="0.45"/>`;
+    })
+    .join('\n');
+  const commitLabels = monthlyRows
+    .map((row, i) => {
+      const x = toX(i);
+      const yTop = scaleY(row.commitCount, maxCommits * 1.08, commitPanel.top, commitPanel.bottom);
+      return `<text x="${x.toFixed(2)}" y="${(yTop - 8).toFixed(0)}" text-anchor="middle" font-size="12" font-weight="600" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">${escapeSvg(formatInteger(row.commitCount))}</text>`;
+    })
+    .join('\n');
+
+  const monthLabels = monthlyRows
+    .map(
+      (row, i) =>
+        `<text x="${toX(i).toFixed(2)}" y="${monthLabelY}" text-anchor="middle" font-size="13" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(row.periodKey)}</text>`,
+    )
+    .join('\n');
 
   const noData =
     monthlyRows.length === 0
       ? `<text x="${(W / 2).toFixed(0)}" y="${(H / 2).toFixed(0)}" text-anchor="middle" font-size="20" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">No monthly efficiency data available</text>`
       : '';
 
-  const vcenter = 70;
-  const commandText = 'llm-usage efficiency monthly --share';
-  const badgeW = commandText.length * 9.5 + 28;
-  const badgeX = W - pad.right - badgeW;
-
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
-  <linearGradient id="accent-grad" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0%" stop-color="#10b981"/>
-    <stop offset="100%" stop-color="#06b6d4"/>
+  ${renderShareAccentGradientDef()}
+  <linearGradient id="usd-area-grad" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="${chartColors.usdPerCommit}" stop-opacity="0.28"/>
+    <stop offset="100%" stop-color="${chartColors.usdPerCommit}" stop-opacity="0.04"/>
   </linearGradient>
 </defs>
 <rect width="${W}" height="${H}" fill="${shareTheme.bg}"/>
 ${renderShareAccentBar()}
-<text x="${pad.left}" y="52" font-size="32" font-weight="700" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">Monthly Efficiency</text>
-<rect x="${badgeX.toFixed(0)}" y="30" width="${badgeW.toFixed(0)}" height="34" rx="17" fill="none" stroke="${shareTheme.cardBorder}"/>
-<text x="${(badgeX + badgeW / 2).toFixed(0)}" y="52" text-anchor="middle" font-size="14" fill="${shareTheme.textMuted}" font-family="${shareTheme.mono}">${escapeSvg(commandText)}</text>
-${renderSummaryStats(allRow, vcenter)}
-${renderLegend(pad.left, vcenter + 50)}
-<line x1="${chartLeft}" y1="${chartBottom}" x2="${chartRight}" y2="${chartBottom}" stroke="${shareTheme.gridLine}" stroke-width="1"/>
-<line x1="${chartLeft}" y1="${chartTop}" x2="${chartLeft}" y2="${chartBottom}" stroke="${shareTheme.gridLine}" stroke-width="1"/>
-<line x1="${chartRight}" y1="${chartTop}" x2="${chartRight}" y2="${chartBottom}" stroke="${shareTheme.gridLine}" stroke-width="1"/>
-${axisLabels}
-${commitBars}
-${renderCommitBarLabels(monthlyRows, chartLeft, stepX, maxCommits, chartTop, chartBottom)}
+<text x="${left}" y="52" font-size="32" font-weight="700" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">Monthly Efficiency</text>
+<text x="${left}" y="76" font-size="15" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">Spend per commit and commit volume, month by month</text>
+${renderShareCommandBadge('llm-usage efficiency monthly --share')}
+${renderSummaryStats(allRow)}
+${renderPanelLabel(usdPanel, '$ / Commit', chartColors.usdPerCommit, formatUsd(actualMaxUsd))}
+${renderPanelFrame(usdPanel)}
+${usdArea}
 ${usdLine}
 ${usdDots}
-${renderUsdDataLabels(monthlyRows, usdPoints)}
+${usdLabels}
+${renderPanelLabel(commitPanel, 'Commits', chartColors.commits, formatInteger(maxCommits))}
+${renderPanelFrame(commitPanel)}
+${commitBars}
+${commitLabels}
 ${monthLabels}
 ${noData}
 ${renderShareFooter({ height: H })}

--- a/src/render/render-optimize-share-svg.ts
+++ b/src/render/render-optimize-share-svg.ts
@@ -5,6 +5,8 @@ import {
   escapeSvg,
   formatUsd,
   renderShareAccentBar,
+  renderShareAccentGradientDef,
+  renderShareCommandBadge,
   renderShareFooter,
   SHARE_SVG_FOOTER_HEIGHT,
   SHARE_SVG_WIDTH,
@@ -12,8 +14,11 @@ import {
 } from './share-svg-theme.js';
 
 const W = SHARE_SVG_WIDTH;
-const H = 780;
-const pad = { top: 180, right: 70, bottom: 60 + SHARE_SVG_FOOTER_HEIGHT, left: 260 };
+const pad = { top: 180, right: 80, bottom: 60 + SHARE_SVG_FOOTER_HEIGHT, left: 260 };
+const CELL_HEIGHT = 96;
+const CELL_MAX_WIDTH = 320;
+const CELL_GAP = 6;
+const MIN_GRID_HEIGHT = 200;
 
 function formatPercent(value: number | undefined): string {
   if (value === undefined) return '-';
@@ -64,17 +69,17 @@ export function renderOptimizeMonthlyShareSvg(optimizeData: OptimizeDataResult):
     if (row.periodKey === 'ALL') allByCandidate.set(row.candidateModel, row);
   }
 
-  const chartLeft = pad.left;
-  const chartTop = pad.top;
-  const chartRight = W - pad.right;
-  const chartBottom = H - pad.bottom;
-  const chartW = chartRight - chartLeft;
-  const chartH = chartBottom - chartTop;
-
   const rowCount = Math.max(1, candidateModels.length);
   const colCount = Math.max(1, periodKeys.length);
-  const cellW = chartW / colCount;
-  const cellH = chartH / rowCount;
+
+  const chartTop = pad.top;
+  const cellH = CELL_HEIGHT;
+  const chartH = Math.max(MIN_GRID_HEIGHT, rowCount * cellH);
+  const chartBottom = chartTop + chartH;
+  const H = chartBottom + pad.bottom;
+  const availableW = W - pad.left - pad.right;
+  const cellW = Math.min(CELL_MAX_WIDTH, availableW / colCount);
+  const chartLeft = pad.left;
 
   const gridCells: string[] = [];
   const colLabels: string[] = [];
@@ -125,7 +130,7 @@ export function renderOptimizeMonthlyShareSvg(optimizeData: OptimizeDataResult):
       const pct = row?.savingsPct;
 
       gridCells.push(
-        `<rect x="${(x + 2).toFixed(2)}" y="${(yTop + 2).toFixed(2)}" width="${Math.max(0, cellW - 4).toFixed(2)}" height="${Math.max(0, cellH - 4).toFixed(2)}" fill="${cellFill(pct)}" rx="6"/>`,
+        `<rect x="${(x + CELL_GAP / 2).toFixed(2)}" y="${(yTop + CELL_GAP / 2).toFixed(2)}" width="${Math.max(0, cellW - CELL_GAP).toFixed(2)}" height="${Math.max(0, cellH - CELL_GAP).toFixed(2)}" fill="${cellFill(pct)}" rx="8"/>`,
       );
       gridCells.push(
         `<text x="${(x + cellW / 2).toFixed(2)}" y="${(yTop + cellH / 2 + 5).toFixed(2)}" text-anchor="middle" font-size="13" font-weight="600" fill="${cellTextFill(pct)}" font-family="${shareTheme.font}">${escapeSvg(formatPercent(pct))}</text>`,
@@ -136,9 +141,6 @@ export function renderOptimizeMonthlyShareSvg(optimizeData: OptimizeDataResult):
   const provider = optimizeData.diagnostics.provider;
   const missing = optimizeData.diagnostics.candidatesWithMissingPricing;
   const warning = optimizeData.diagnostics.warning ?? '';
-  const commandText = 'llm-usage optimize monthly --share';
-  const badgeW = commandText.length * 9.5 + 28;
-  const badgeX = W - pad.right - badgeW;
 
   const noData =
     candidateModels.length === 0 || periodKeys.length === 0
@@ -147,23 +149,18 @@ export function renderOptimizeMonthlyShareSvg(optimizeData: OptimizeDataResult):
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
-  <linearGradient id="accent-grad" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0%" stop-color="#10b981"/>
-    <stop offset="100%" stop-color="#06b6d4"/>
-  </linearGradient>
+  ${renderShareAccentGradientDef()}
 </defs>
 <rect width="${W}" height="${H}" fill="${shareTheme.bg}"/>
 ${renderShareAccentBar()}
 <text x="${pad.left}" y="52" font-size="32" font-weight="700" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">Monthly Optimize</text>
 <text x="${pad.left}" y="78" font-size="15" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">Savings % heatmap by candidate and month</text>
-<rect x="${badgeX.toFixed(0)}" y="30" width="${badgeW.toFixed(0)}" height="34" rx="17" fill="none" stroke="${shareTheme.cardBorder}"/>
-<text x="${(badgeX + badgeW / 2).toFixed(0)}" y="52" text-anchor="middle" font-size="14" fill="${shareTheme.textMuted}" font-family="${shareTheme.mono}">${escapeSvg(commandText)}</text>
+${renderShareCommandBadge('llm-usage optimize monthly --share')}
 <text x="${pad.left}" y="112" font-size="15" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">Provider: <tspan font-weight="700">${escapeSvg(provider)}</tspan></text>
 <text x="${pad.left + 280}" y="112" font-size="14" fill="#22c55e" font-family="${shareTheme.font}">● positive = savings</text>
 <text x="${pad.left + 480}" y="112" font-size="14" fill="#ef4444" font-family="${shareTheme.font}">● negative = higher cost</text>
 ${missing.length > 0 ? `<text x="${pad.left}" y="136" font-size="13" fill="#eab308" font-family="${shareTheme.font}">Missing pricing: ${escapeSvg(missing.join(', '))}</text>` : ''}
 ${warning ? `<text x="${pad.left}" y="158" font-size="13" fill="#eab308" font-family="${shareTheme.font}">${escapeSvg(warning)}</text>` : ''}
-<rect x="${chartLeft}" y="${chartTop}" width="${chartW}" height="${chartH}" fill="${shareTheme.cardBg}" rx="10"/>
 ${gridCells.join('\n')}
 ${colLabels.join('\n')}
 ${rowLabels.join('\n')}

--- a/src/render/render-trends-share-svg.ts
+++ b/src/render/render-trends-share-svg.ts
@@ -6,6 +6,8 @@ import {
   formatCompact,
   formatUsd,
   renderShareAccentBar,
+  renderShareAccentGradientDef,
+  renderShareCommandBadge,
   renderShareFooter,
   scaleY,
   SHARE_SVG_FOOTER_HEIGHT,
@@ -15,8 +17,8 @@ import {
 } from './share-svg-theme.js';
 
 const W = SHARE_SVG_WIDTH;
-const H = 560;
-const pad = { top: 165, right: 110, bottom: 70 + SHARE_SVG_FOOTER_HEIGHT, left: 120 };
+const H = 580;
+const pad = { top: 180, right: 80, bottom: 70 + SHARE_SVG_FOOTER_HEIGHT, left: 120 };
 
 const chartColors: Record<TrendsMetric, string> = {
   cost: '#10b981',
@@ -63,28 +65,39 @@ function renderSummaryStats(data: TrendsDataResult): string {
     {
       label: 'Avg / Day',
       value: formatMetricValue(totalSeries.summary.average, metric, approximate),
-      x: 350,
+      x: pad.left + 260,
     },
     {
       label: 'Peak',
-      value: `${formatMetricValue(totalSeries.summary.peak.value, metric, approximate)} ${totalSeries.summary.peak.date}`,
-      x: 580,
+      value: formatMetricValue(totalSeries.summary.peak.value, metric, approximate),
+      date: totalSeries.summary.peak.date,
+      x: pad.left + 520,
     },
     {
       label: 'Min',
       value: minBucket
-        ? `${formatMetricValue(minBucket.value, metric, minBucket.incomplete === true)} ${minBucket.date}`
+        ? formatMetricValue(minBucket.value, metric, minBucket.incomplete === true)
         : '-',
-      x: 910,
+      date: minBucket?.date,
+      x: pad.left + 780,
     },
   ];
 
   return stats
-    .map(
-      (stat) =>
-        `<text x="${stat.x}" y="92" font-size="13" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(stat.label)}</text>` +
-        `<text x="${stat.x}" y="118" font-size="20" font-weight="700" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">${escapeSvg(stat.value)}</text>`,
-    )
+    .map((stat) => {
+      const lines = [
+        `<text x="${stat.x}" y="92" font-size="13" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(stat.label)}</text>`,
+        `<text x="${stat.x}" y="118" font-size="22" font-weight="700" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">${escapeSvg(stat.value)}</text>`,
+      ];
+
+      if (stat.date !== undefined) {
+        lines.push(
+          `<text x="${stat.x}" y="138" font-size="12" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(stat.date)}</text>`,
+        );
+      }
+
+      return lines.join('\n');
+    })
     .join('\n');
 }
 
@@ -185,11 +198,16 @@ export function renderTrendsShareSvg(data: TrendsDataResult): string {
     y: scaleY(bucket.value, scaleMax, chartTop, chartBottom),
   }));
   const commandText = 'llm-usage trends --share';
-  const badgeW = commandText.length * 9.5 + 28;
-  const badgeX = W - pad.right - badgeW;
   const title = `Daily ${getMetricLabel(data.metric)} Trend`;
-  const subtitle = `${bucketCount} ${getDayLabel(bucketCount)} - ${getDateRangeLabel(data)}`;
-  const seriesLabel = `Series: ${data.totalSeries.source}`;
+  const subtitle = `${bucketCount} ${getDayLabel(bucketCount)} - ${getDateRangeLabel(data)} · ${data.totalSeries.source}`;
+  const peakIndex = buckets.findIndex(
+    (bucket) => bucket.date === data.totalSeries.summary.peak.date,
+  );
+  const peakPoint = peakIndex >= 0 ? points[peakIndex] : undefined;
+  const peakMarker =
+    bucketCount > 1 && peakPoint
+      ? `<circle data-peak="${escapeSvg(data.totalSeries.summary.peak.date)}" cx="${peakPoint.x.toFixed(2)}" cy="${peakPoint.y.toFixed(2)}" r="9" fill="none" stroke="${color}" stroke-width="2" stroke-opacity="0.7"/>`
+      : '';
   const chartContent =
     bucketCount === 0
       ? `<text x="${(W / 2).toFixed(0)}" y="${(H / 2).toFixed(0)}" text-anchor="middle" font-size="20" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">No trend data available</text>`
@@ -197,10 +215,7 @@ export function renderTrendsShareSvg(data: TrendsDataResult): string {
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
-  <linearGradient id="accent-grad" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0%" stop-color="#10b981"/>
-    <stop offset="100%" stop-color="#06b6d4"/>
-  </linearGradient>
+  ${renderShareAccentGradientDef()}
   <linearGradient id="trend-area-grad" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="${color}" stop-opacity="0.42"/>
     <stop offset="100%" stop-color="${color}" stop-opacity="0.08"/>
@@ -213,12 +228,11 @@ export function renderTrendsShareSvg(data: TrendsDataResult): string {
 ${renderShareAccentBar()}
 <text x="${pad.left}" y="52" font-size="32" font-weight="700" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">${escapeSvg(title)}</text>
 <text x="${pad.left}" y="78" font-size="15" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">${escapeSvg(subtitle)}</text>
-<rect x="${badgeX.toFixed(0)}" y="30" width="${badgeW.toFixed(0)}" height="34" rx="17" fill="none" stroke="${shareTheme.cardBorder}"/>
-<text x="${(badgeX + badgeW / 2).toFixed(0)}" y="52" text-anchor="middle" font-size="14" fill="${shareTheme.textMuted}" font-family="${shareTheme.mono}">${escapeSvg(commandText)}</text>
+${renderShareCommandBadge(commandText)}
 ${renderSummaryStats(data)}
-<text x="${chartLeft}" y="${(chartTop - 22).toFixed(0)}" font-size="13" fill="${color}" font-family="${shareTheme.font}">${escapeSvg(seriesLabel)}</text>
 ${renderGridLines(chartLeft, chartRight, chartTop, chartBottom, scaleMax, data.metric)}
 ${chartContent}
+${peakMarker}
 ${renderDateLabels(buckets, toX, chartBottom + 30)}
 ${renderShareFooter({ height: H, rightText: getDateRangeLabel(data) })}
 </svg>`;

--- a/src/render/render-usage-share-svg.ts
+++ b/src/render/render-usage-share-svg.ts
@@ -9,9 +9,10 @@ import {
   formatUsd,
   getSourceColor,
   renderShareAccentBar,
+  renderShareAccentGradientDef,
+  renderShareCommandBadge,
   renderShareFooter,
   scaleY,
-  SHARE_SVG_ACCENT_HEIGHT,
   SHARE_SVG_FOOTER_HEIGHT,
   SHARE_SVG_WIDTH,
   shareTheme,
@@ -19,21 +20,16 @@ import {
 } from './share-svg-theme.js';
 
 const W = SHARE_SVG_WIDTH;
-const H_BASE = 560;
-const pad = { top: 140, right: 80, bottom: 60 + SHARE_SVG_FOOTER_HEIGHT, left: 200 };
-const STAT_X = 60;
-const STAT_VALUE_FONT_SIZE = 52;
-const STAT_VALUE_WIDTH_FACTOR = 0.6;
-const SOURCE_PILLS_MIN_X = pad.left + 10;
-const SOURCE_PILLS_STAT_GAP = 24;
-const SOURCE_PILLS_TOP = SHARE_SVG_ACCENT_HEIGHT + 30;
-const SOURCE_PILLS_RIGHT_MARGIN = 60;
-const SOURCE_PILLS_COMMAND_GAP = 20;
-const PILL_HEIGHT = 30;
-const PILL_ROW_HEIGHT = PILL_HEIGHT + 10;
-const PILL_GAP = 10;
-const PILL_PADDING = 28;
-const PILL_TEXT_WIDTH_FACTOR = 8.5;
+const H_BASE = 620;
+const left = 80;
+const right = 80;
+const statTop = 96;
+const legendTop = 158;
+const LEGEND_ROW_HEIGHT = 30;
+const LEGEND_ITEM_GAP = 28;
+const LEGEND_TEXT_WIDTH_FACTOR = 8;
+const chartTopBase = 208;
+const pad = { bottom: 60 + SHARE_SVG_FOOTER_HEIGHT };
 
 type SourceSeries = {
   source: string;
@@ -91,108 +87,76 @@ function buildStackedValues(series: SourceSeries[]): number[][] {
   return stacked;
 }
 
-/** Left-side stat column: big token count + cost. */
-function renderStatColumn(
+function granularityTitle(granularity: ReportGranularity): string {
+  return `${granularity.charAt(0).toUpperCase()}${granularity.slice(1)} Usage`;
+}
+
+/** Stats row under the title: Tokens, Cost, Sources as label-over-value pairs. */
+function renderStatsRow(
   totalTokens: number,
   costUsd: number | undefined,
   sourceCount: number,
 ): string {
-  const x = STAT_X;
-  const baseY = SHARE_SVG_ACCENT_HEIGHT + 48;
-  let svg = '';
+  const stats = [
+    { label: 'Tokens', value: formatCompact(totalTokens), x: left },
+    { label: 'Cost', value: costUsd === undefined ? '-' : formatUsd(costUsd), x: left + 240 },
+    { label: 'Sources', value: String(sourceCount), x: left + 480 },
+  ];
 
-  svg += `<text x="${x}" y="${baseY}" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}" font-size="52" font-weight="800">${escapeSvg(formatCompact(totalTokens))}</text>\n`;
-  svg += `<text x="${x}" y="${baseY + 22}" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}" font-size="14" letter-spacing="3" font-weight="600">TOKENS</text>\n`;
-
-  if (costUsd !== undefined) {
-    svg += `<text x="${x}" y="${baseY + 50}" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}" font-size="22" font-weight="600">${escapeSvg(formatUsd(costUsd))}</text>\n`;
-  }
-
-  svg += `<text x="${x}" y="${baseY + 74}" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}" font-size="13">${sourceCount} source${sourceCount !== 1 ? 's' : ''}</text>\n`;
-
-  return svg;
+  return stats
+    .map(
+      (stat) =>
+        `<text x="${stat.x}" y="${statTop}" font-size="13" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${escapeSvg(stat.label)}</text>` +
+        `<text x="${stat.x}" y="${statTop + 30}" font-size="26" font-weight="800" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">${escapeSvg(stat.value)}</text>`,
+    )
+    .join('\n');
 }
 
-type PillLayout = {
+type LegendItem = {
   color: string;
-  label: string;
+  source: string;
+  total: string;
   x: number;
   y: number;
-  width: number;
 };
 
-/**
- * Wraps source pills into as many rows as needed. The first row starts right
- * of the stat total and stops before the command badge; wrapped rows start at
- * the left margin and span nearly the full canvas width.
- */
-function layoutSourcePills(
-  series: SourceSeries[],
-  firstRowStartX: number,
-  firstRowRightEdge: number,
-): { pills: PillLayout[]; rowCount: number } {
-  const pills: PillLayout[] = [];
-  const wrappedRowRightEdge = W - SOURCE_PILLS_RIGHT_MARGIN;
+/** Wraps legend items (dot + source + total) into as many rows as needed. */
+function layoutLegend(series: SourceSeries[]): { items: LegendItem[]; rowCount: number } {
+  const items: LegendItem[] = [];
+  const rightEdge = W - right;
   let row = 0;
-  let cx = firstRowStartX;
+  let cx = left;
 
   for (const s of series) {
-    const label = `${s.source}  ${formatCompact(s.total)}`;
-    const width = label.length * PILL_TEXT_WIDTH_FACTOR + PILL_PADDING;
-    const rowStartX = row === 0 ? firstRowStartX : SOURCE_PILLS_MIN_X;
-    const rowRightEdge = row === 0 ? firstRowRightEdge : wrappedRowRightEdge;
+    const total = formatCompact(s.total);
+    const width = (s.source.length + total.length + 1) * LEGEND_TEXT_WIDTH_FACTOR + 18;
 
-    if (cx > rowStartX && cx + width > rowRightEdge) {
+    if (cx > left && cx + width > rightEdge) {
       row += 1;
-      cx = SOURCE_PILLS_MIN_X;
+      cx = left;
     }
 
-    pills.push({
+    items.push({
       color: s.color,
-      label,
+      source: s.source,
+      total,
       x: cx,
-      y: SOURCE_PILLS_TOP + row * PILL_ROW_HEIGHT,
-      width,
+      y: legendTop + row * LEGEND_ROW_HEIGHT,
     });
-    cx += width + PILL_GAP;
+    cx += width + LEGEND_ITEM_GAP;
   }
 
-  return { pills, rowCount: row + 1 };
+  return { items, rowCount: row + 1 };
 }
 
-/** Source pills: rounded pill badges wrapped across the top. */
-function renderSourcePills(pills: PillLayout[]): string {
-  let svg = '';
-
-  for (const pill of pills) {
-    svg += `<rect x="${pill.x}" y="${pill.y}" width="${pill.width.toFixed(0)}" height="${PILL_HEIGHT}" rx="${PILL_HEIGHT / 2}" fill="${pill.color}" fill-opacity="0.15" stroke="${pill.color}" stroke-opacity="0.4" stroke-width="1"/>\n`;
-    svg += `<circle cx="${pill.x + 14}" cy="${pill.y + PILL_HEIGHT / 2}" r="4" fill="${pill.color}"/>\n`;
-    svg += `<text x="${pill.x + 24}" y="${pill.y + PILL_HEIGHT / 2 + 5}" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}" font-size="14">${escapeSvg(pill.label)}</text>\n`;
-  }
-
-  return svg;
-}
-
-function estimateStatValueRightEdge(totalTokens: number): number {
-  const value = formatCompact(totalTokens);
-  return STAT_X + value.length * STAT_VALUE_FONT_SIZE * STAT_VALUE_WIDTH_FACTOR;
-}
-
-function commandBadgeWidth(command: string): number {
-  return command.length * 9 + 28;
-}
-
-/** Command badge positioned in the top-right corner. */
-function renderCommandBadge(command: string): string {
-  const badgeW = commandBadgeWidth(command);
-  const badgeH = 30;
-  const x = W - 60 - badgeW;
-  const y = SHARE_SVG_ACCENT_HEIGHT + 30;
-
-  return [
-    `<rect x="${x}" y="${y}" width="${badgeW}" height="${badgeH}" rx="${badgeH / 2}" fill="none" stroke="${shareTheme.cardBorder}" stroke-width="1"/>`,
-    `<text x="${x + badgeW / 2}" y="${y + badgeH / 2 + 5}" text-anchor="middle" font-size="13" fill="${shareTheme.textMuted}" font-family="${shareTheme.mono}">${escapeSvg(command)}</text>`,
-  ].join('\n');
+function renderLegend(items: LegendItem[]): string {
+  return items
+    .map(
+      (item) =>
+        `<circle data-legend="${escapeSvg(item.source)}" cx="${item.x + 5}" cy="${item.y}" r="5" fill="${item.color}"/>` +
+        `<text x="${item.x + 18}" y="${item.y + 5}" font-size="14" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">${escapeSvg(item.source)} <tspan fill="${shareTheme.textMuted}">${escapeSvg(item.total)}</tspan></text>`,
+    )
+    .join('\n');
 }
 
 function renderGridLines(
@@ -340,18 +304,13 @@ export function renderUsageShareSvg(
   const totalCost = grandTotal?.costUsd;
 
   const commandText = `llm-usage ${granularity} --share`;
-  const firstRowStartX = Math.max(
-    SOURCE_PILLS_MIN_X,
-    estimateStatValueRightEdge(totalTokens) + SOURCE_PILLS_STAT_GAP,
-  );
-  const firstRowRightEdge = W - 60 - commandBadgeWidth(commandText) - SOURCE_PILLS_COMMAND_GAP;
-  const { pills, rowCount } = layoutSourcePills(activeSeries, firstRowStartX, firstRowRightEdge);
-  const extraHeight = (rowCount - 1) * PILL_ROW_HEIGHT;
+  const { items: legendItems, rowCount } = layoutLegend(activeSeries);
+  const extraHeight = (rowCount - 1) * LEGEND_ROW_HEIGHT;
   const H = H_BASE + extraHeight;
 
-  const chartLeft = pad.left;
-  const chartTop = pad.top + extraHeight;
-  const chartRight = W - pad.right;
+  const chartLeft = left + 40;
+  const chartTop = chartTopBase + extraHeight;
+  const chartRight = W - right;
   const chartBottom = H - pad.bottom;
   const chartW = chartRight - chartLeft;
   const chartH = chartBottom - chartTop;
@@ -390,10 +349,7 @@ export function renderUsageShareSvg(
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
-  <linearGradient id="accent-grad" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0%" stop-color="#10b981"/>
-    <stop offset="100%" stop-color="#06b6d4"/>
-  </linearGradient>
+  ${renderShareAccentGradientDef()}
   <clipPath id="chart-clip">
     <rect x="${chartLeft}" y="${chartTop - 4}" width="${chartW}" height="${chartH + 8}"/>
   </clipPath>
@@ -401,9 +357,11 @@ export function renderUsageShareSvg(
 </defs>
 <rect width="${W}" height="${H}" fill="${shareTheme.bg}"/>
 ${renderShareAccentBar()}
-${renderStatColumn(totalTokens, totalCost, activeSeries.length)}
-${renderSourcePills(pills)}
-${renderCommandBadge(commandText)}
+<text x="${left}" y="52" font-size="32" font-weight="700" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">${escapeSvg(granularityTitle(granularity))}</text>
+<text x="${left}" y="76" font-size="15" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">Token usage by source over ${formatFooterRange(periods) || 'the selected window'}</text>
+${renderShareCommandBadge(commandText)}
+${renderStatsRow(totalTokens, totalCost, activeSeries.length)}
+${renderLegend(legendItems)}
 ${renderGridLines(chartLeft, chartRight, chartTop, chartH, maxY)}
 ${chartContent}
 ${renderPeriodLabels(periods, toX, chartBottom)}

--- a/src/render/render-wrapped-share-svg.ts
+++ b/src/render/render-wrapped-share-svg.ts
@@ -5,13 +5,15 @@ import {
   formatCompact,
   formatInteger,
   renderShareAccentBar,
+  renderShareAccentGradientDef,
+  renderShareCommandBadge,
   renderShareFooter,
   SHARE_SVG_WIDTH,
   shareTheme,
 } from './share-svg-theme.js';
 
 const W = SHARE_SVG_WIDTH;
-const H = 900;
+const H = 940;
 const left = 80;
 const right = 80;
 const tileTop = 172;
@@ -19,8 +21,13 @@ const tileWidth = 300;
 const tileHeight = 126;
 const tileGap = 28;
 const listTop = 360;
-const monthTop = 700;
-const levelColors = ['#21262d', '#14532d', '#15803d', '#22c55e', '#86efac'] as const;
+const heatTitleTop = 668;
+const heatGridTop = 726;
+const heatCellSize = 20;
+const heatCellPitch = 24;
+const heatGridLeft = left + 42;
+// Single-hue ramp (dark to light) matching the site accent, plus the empty-cell gray.
+const levelColors = ['#21262d', '#4a2a1c', '#7d4224', '#c26535', '#f59d70'] as const;
 
 function formatDayLabel(count: number): string {
   return count === 1 ? 'day' : 'days';
@@ -70,27 +77,80 @@ ${rows}
 </g>`;
 }
 
-function renderMonthlyIntensity(data: WrappedRecap): string {
-  const availableWidth = W - left - right;
-  const gap = 12;
-  const cellWidth = (availableWidth - gap * 11) / 12;
-  const monthLabels = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
-  const cells = data.monthlyIntensity
-    .map((month, index) => {
-      const x = left + index * (cellWidth + gap);
-      const labelX = x + cellWidth / 2;
-      const color = levelColors[month.level];
+const MONTH_LABELS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+const WEEKDAY_LABELS: readonly { row: number; label: string }[] = [
+  { row: 1, label: 'Mon' },
+  { row: 3, label: 'Wed' },
+  { row: 5, label: 'Fri' },
+];
+const MS_PER_DAY = 86_400_000;
 
-      return `<g data-month="${escapeSvg(month.month)}" data-level="${month.level}">
-<rect x="${x.toFixed(2)}" y="${monthTop}" width="${cellWidth.toFixed(2)}" height="74" rx="14" fill="${color}" stroke="${shareTheme.cardBorder}"/>
-<text x="${labelX.toFixed(2)}" y="${monthTop + 103}" text-anchor="middle" font-size="13" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${monthLabels[index]}</text>
-</g>`;
-    })
+function renderHeatLegend(): string {
+  const swatch = 12;
+  const gap = 4;
+  const rightEdge = W - right;
+  const swatchesWidth = levelColors.length * (swatch + gap) - gap;
+  const moreX = rightEdge;
+  const swatchesX = rightEdge - 34 - swatchesWidth;
+  const lessX = swatchesX - 8;
+  const y = heatTitleTop + 18;
+  const swatches = levelColors
+    .map(
+      (color, index) =>
+        `<rect x="${swatchesX + index * (swatch + gap)}" y="${y}" width="${swatch}" height="${swatch}" rx="3" fill="${color}"/>`,
+    )
     .join('\n');
 
+  return `<g data-heat-legend="true">
+<text x="${lessX}" y="${y + 10}" text-anchor="end" font-size="12" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">Less</text>
+${swatches}
+<text x="${moreX}" y="${y + 10}" text-anchor="end" font-size="12" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">More</text>
+</g>`;
+}
+
+function renderDailyHeatmap(data: WrappedRecap): string {
+  const yearStartDow = new Date(`${data.from}T00:00:00Z`).getUTCDay();
+  const cells = data.dailyIntensity
+    .map((day, index) => {
+      const row = (yearStartDow + index) % 7;
+      const column = Math.floor((yearStartDow + index) / 7);
+      const x = heatGridLeft + column * heatCellPitch;
+      const y = heatGridTop + row * heatCellPitch;
+
+      return `<rect data-date="${escapeSvg(day.date)}" data-level="${day.level}" x="${x}" y="${y}" width="${heatCellSize}" height="${heatCellSize}" rx="4" fill="${levelColors[day.level]}"/>`;
+    })
+    .join('\n');
+  const monthLabels = MONTH_LABELS.map((label, monthIndex) => {
+    const dayOfYear = (Date.UTC(data.year, monthIndex, 1) - Date.UTC(data.year, 0, 1)) / MS_PER_DAY;
+    const column = Math.floor((yearStartDow + dayOfYear) / 7);
+    const x = heatGridLeft + column * heatCellPitch;
+
+    return `<text x="${x}" y="${heatGridTop - 12}" font-size="12" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${label}</text>`;
+  }).join('\n');
+  const weekdayLabels = WEEKDAY_LABELS.map(
+    ({ row, label }) =>
+      `<text x="${heatGridLeft - 12}" y="${heatGridTop + row * heatCellPitch + 14}" text-anchor="end" font-size="12" fill="${shareTheme.textMuted}" font-family="${shareTheme.font}">${label}</text>`,
+  ).join('\n');
+
   return `<g>
-<text x="${left}" y="${monthTop - 34}" font-size="24" font-weight="800" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">Monthly intensity</text>
-<text x="${left}" y="${monthTop - 10}" font-size="15" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">Token usage scaled against your busiest month</text>
+<text x="${left}" y="${heatTitleTop}" font-size="24" font-weight="800" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">Daily activity</text>
+<text x="${left}" y="${heatTitleTop + 26}" font-size="15" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">Tokens per day, shaded by quartile of your active days</text>
+${renderHeatLegend()}
+${monthLabels}
+${weekdayLabels}
 ${cells}
 </g>`;
 }
@@ -98,31 +158,24 @@ ${cells}
 export function renderWrappedShareSvg(data: WrappedRecap): string {
   const commandText = `llm-usage wrapped --year ${data.year} --share`;
   const cost = formatApproxUsd(data.totalCostUsd, data.costIncomplete);
-  const badgeW = commandText.length * 9.5 + 28;
-  const badgeX = W - right - badgeW;
   const footerLabel = `${data.from} to ${data.to}`;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
-  <linearGradient id="accent-grad" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0%" stop-color="#f97316"/>
-    <stop offset="50%" stop-color="#22c55e"/>
-    <stop offset="100%" stop-color="#06b6d4"/>
-  </linearGradient>
+  ${renderShareAccentGradientDef()}
 </defs>
 <rect width="${W}" height="${H}" fill="${shareTheme.bg}"/>
 ${renderShareAccentBar()}
 <text x="${left}" y="78" font-size="44" font-weight="900" fill="${shareTheme.textPrimary}" font-family="${shareTheme.font}">${data.year} Wrapped</text>
 <text x="${left}" y="112" font-size="18" fill="${shareTheme.textSecondary}" font-family="${shareTheme.font}">Your local LLM usage recap</text>
-<rect x="${badgeX.toFixed(0)}" y="54" width="${badgeW.toFixed(0)}" height="34" rx="17" fill="none" stroke="${shareTheme.cardBorder}"/>
-<text x="${(badgeX + badgeW / 2).toFixed(0)}" y="76" text-anchor="middle" font-size="14" fill="${shareTheme.textMuted}" font-family="${shareTheme.mono}">${escapeSvg(commandText)}</text>
+${renderShareCommandBadge(commandText)}
 ${renderStatTile(0, 'Tokens', formatCompact(data.totalTokens), `${formatInteger(data.eventCount)} events`)}
 ${renderStatTile(1, 'Cost', cost, 'estimated spend')}
 ${renderStatTile(2, 'Active Days', formatInteger(data.activeDays), `${formatInteger(data.sessionCount)} sessions`)}
 ${renderStatTile(3, 'Streak', formatInteger(data.longestStreak), formatDayLabel(data.longestStreak))}
 ${renderTopList('Top Models', data.topModels, left)}
 ${renderTopList('Top Sources', data.topSources, W - right - 640)}
-${renderMonthlyIntensity(data)}
+${renderDailyHeatmap(data)}
 ${renderShareFooter({ height: H, rightText: footerLabel })}
 </svg>`;
 }

--- a/src/render/share-svg-theme.ts
+++ b/src/render/share-svg-theme.ts
@@ -63,6 +63,26 @@ export function renderShareAccentBar(width = SHARE_SVG_WIDTH): string {
   return `<rect width="${width}" height="${SHARE_SVG_ACCENT_HEIGHT}" fill="url(#accent-grad)"/>`;
 }
 
+/** The brand gradient behind the accent bar; identical across every share card. */
+export function renderShareAccentGradientDef(): string {
+  return `<linearGradient id="accent-grad" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0%" stop-color="#f97316"/>
+    <stop offset="50%" stop-color="#22c55e"/>
+    <stop offset="100%" stop-color="#06b6d4"/>
+  </linearGradient>`;
+}
+
+/** Command badge pinned to the top-right corner, same spot on every share card. */
+export function renderShareCommandBadge(command: string): string {
+  const badgeW = command.length * 9.5 + 28;
+  const badgeX = SHARE_SVG_WIDTH - 80 - badgeW;
+
+  return [
+    `<rect x="${badgeX.toFixed(0)}" y="30" width="${badgeW.toFixed(0)}" height="34" rx="17" fill="none" stroke="${shareTheme.cardBorder}"/>`,
+    `<text x="${(badgeX + badgeW / 2).toFixed(0)}" y="52" text-anchor="middle" font-size="14" fill="${shareTheme.textMuted}" font-family="${shareTheme.mono}">${escapeSvg(command)}</text>`,
+  ].join('\n');
+}
+
 export function renderShareFooter(options: {
   height: number;
   width?: number;

--- a/src/sources/create-default-adapters.ts
+++ b/src/sources/create-default-adapters.ts
@@ -16,8 +16,11 @@ import type { SourceAdapter } from './source-adapter.js';
 import { compareByCodePoint } from '../utils/compare-by-code-point.js';
 import { parseSourceDirectoryOverrides } from '../utils/source-directory-overrides.js';
 
+export type SourceStorageFormat = 'jsonl' | 'json' | 'sqlite';
+
 type SourceRegistration = {
   id: string;
+  format: SourceStorageFormat;
   sourceDirOverride: { kind: 'directory' } | { kind: 'unsupported'; flag: string };
   create: (
     options: CreateDefaultAdaptersOptions,
@@ -48,6 +51,7 @@ export type CreateDefaultAdaptersOptions = {
 const sourceRegistrations: readonly SourceRegistration[] = [
   {
     id: 'pi',
+    format: 'jsonl',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig('pi', options.piDir, sourceDirectoryOverrides);
@@ -60,6 +64,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'codex',
+    format: 'jsonl',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -76,6 +81,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'gemini',
+    format: 'json',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -92,6 +98,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'droid',
+    format: 'json',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -108,6 +115,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'opencode',
+    format: 'sqlite',
     sourceDirOverride: { kind: 'unsupported', flag: '--opencode-db' },
     create: (options) =>
       new OpenCodeSourceAdapter({
@@ -116,6 +124,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'openclaw',
+    format: 'jsonl',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -132,6 +141,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'claude',
+    format: 'jsonl',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -148,6 +158,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'copilot',
+    format: 'jsonl',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -164,6 +175,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'goose',
+    format: 'sqlite',
     sourceDirOverride: { kind: 'unsupported', flag: '--goose-db' },
     create: (options) =>
       new GooseSourceAdapter({
@@ -172,6 +184,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'amp',
+    format: 'json',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -188,6 +201,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'qwen',
+    format: 'jsonl',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -204,6 +218,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'kimi',
+    format: 'jsonl',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -220,6 +235,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'cline',
+    format: 'json',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -238,6 +254,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'roocode',
+    format: 'json',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -256,6 +273,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'kilocode',
+    format: 'json',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -274,6 +292,7 @@ const sourceRegistrations: readonly SourceRegistration[] = [
   },
   {
     id: 'antigravity',
+    format: 'sqlite',
     sourceDirOverride: { kind: 'directory' },
     create: (options, sourceDirectoryOverrides) => {
       const directoryConfig = resolveDirectoryConfig(
@@ -412,6 +431,16 @@ function resolveDirectoryConfig(
 
 export function getDefaultSourceIds(): string[] {
   return sourceRegistrations.map((source) => source.id);
+}
+
+export function getSourceStorageFormat(sourceId: string): SourceStorageFormat {
+  const registration = sourceRegistrations.find((source) => source.id === sourceId);
+
+  if (!registration) {
+    throw new Error(`Unknown source id: ${sourceId}`);
+  }
+
+  return registration.format;
 }
 
 export function createDefaultAdapters(options: CreateDefaultAdaptersOptions): SourceAdapter[] {

--- a/src/wrapped/aggregate-wrapped.ts
+++ b/src/wrapped/aggregate-wrapped.ts
@@ -1,7 +1,7 @@
 import type { UsageEvent } from '../domain/usage-event.js';
 import { compareByCodePoint } from '../utils/compare-by-code-point.js';
 import { getPeriodKey, shiftLocalDateKey } from '../utils/time-buckets.js';
-import type { WrappedMonth, WrappedRecap, WrappedTopItem } from './wrapped-recap.js';
+import type { WrappedDay, WrappedMonth, WrappedRecap, WrappedTopItem } from './wrapped-recap.js';
 
 export type AggregateWrappedOptions = {
   year: number;
@@ -154,6 +154,69 @@ function buildMonthlyIntensity(
   });
 }
 
+function createDateKeys(range: { from: string; to: string }): string[] {
+  const dateKeys: string[] = [];
+
+  for (let dateKey = range.from; dateKey <= range.to; dateKey = shiftLocalDateKey(dateKey, 1)) {
+    dateKeys.push(dateKey);
+  }
+
+  return dateKeys;
+}
+
+// Quartile banding over active days keeps the heatmap readable when one
+// outlier day dwarfs the rest; max-scaling would flatten everything to level 1.
+function toDailyLevelThresholds(activeDayTokens: number[]): [number, number, number] {
+  const sorted = [...activeDayTokens].sort((left, right) => left - right);
+  const quantile = (fraction: number) => sorted[Math.floor(fraction * (sorted.length - 1))] ?? 0;
+
+  return [quantile(0.25), quantile(0.5), quantile(0.75)];
+}
+
+function toDailyLevel(
+  totalTokens: number,
+  thresholds: readonly [number, number, number],
+): WrappedDay['level'] {
+  if (totalTokens <= 0) {
+    return 0;
+  }
+
+  if (totalTokens <= thresholds[0]) {
+    return 1;
+  }
+
+  if (totalTokens <= thresholds[1]) {
+    return 2;
+  }
+
+  if (totalTokens <= thresholds[2]) {
+    return 3;
+  }
+
+  return 4;
+}
+
+function buildDailyIntensity(
+  range: { from: string; to: string },
+  dailyTotals: Map<string, TotalsAccumulator>,
+): WrappedDay[] {
+  const dateKeys = createDateKeys(range);
+  const activeDayTokens = dateKeys
+    .map((dateKey) => dailyTotals.get(dateKey)?.totalTokens ?? 0)
+    .filter((totalTokens) => totalTokens > 0);
+  const thresholds = toDailyLevelThresholds(activeDayTokens);
+
+  return dateKeys.map((dateKey) => {
+    const totalTokens = dailyTotals.get(dateKey)?.totalTokens ?? 0;
+
+    return {
+      date: dateKey,
+      totalTokens,
+      level: toDailyLevel(totalTokens, thresholds),
+    };
+  });
+}
+
 function isInYearRange(dateKey: string, range: { from: string; to: string }): boolean {
   return dateKey >= range.from && dateKey <= range.to;
 }
@@ -173,6 +236,7 @@ export function aggregateWrapped(
   const modelGroups = new Map<string, TotalsAccumulator>();
   const sourceGroups = new Map<string, TotalsAccumulator>();
   const monthlyTotals = new Map<string, TotalsAccumulator>();
+  const dailyTotals = new Map<string, TotalsAccumulator>();
   const total: TotalsAccumulator = { totalTokens: 0 };
   let eventCount = 0;
 
@@ -189,6 +253,7 @@ export function aggregateWrapped(
     addEventTotals(total, event);
     addGroupedEvent(sourceGroups, event.source, event);
     addGroupedEvent(monthlyTotals, dateKey.slice(0, 7), event);
+    addGroupedEvent(dailyTotals, dateKey, event);
 
     if (event.model) {
       addGroupedEvent(modelGroups, event.model, event);
@@ -212,5 +277,6 @@ export function aggregateWrapped(
     topModels: toTopItems(modelGroups),
     topSources: toTopItems(sourceGroups),
     monthlyIntensity: buildMonthlyIntensity(monthKeys, monthlyTotals),
+    dailyIntensity: buildDailyIntensity(range, dailyTotals),
   };
 }

--- a/src/wrapped/wrapped-recap.ts
+++ b/src/wrapped/wrapped-recap.ts
@@ -13,6 +13,12 @@ export type WrappedMonth = {
   level: 0 | 1 | 2 | 3 | 4;
 };
 
+export type WrappedDay = {
+  date: string;
+  totalTokens: number;
+  level: 0 | 1 | 2 | 3 | 4;
+};
+
 export type WrappedRecap = {
   year: number;
   timezone: string;
@@ -28,4 +34,5 @@ export type WrappedRecap = {
   topModels: WrappedTopItem[];
   topSources: WrappedTopItem[];
   monthlyIntensity: WrappedMonth[];
+  dailyIntensity: WrappedDay[];
 };

--- a/tests/cli/run-doctor-report.test.ts
+++ b/tests/cli/run-doctor-report.test.ts
@@ -186,22 +186,22 @@ describe('run-doctor-report', () => {
     const results = await buildDoctorResults(options, eventStoreDisabledDeps());
 
     expect(results).toEqual([
-      { id: 'pi', status: 'ok', itemsFound: 1 },
-      { id: 'codex', status: 'ok', itemsFound: 1 },
-      { id: 'gemini', status: 'ok', itemsFound: 1 },
-      { id: 'droid', status: 'ok', itemsFound: 1 },
-      { id: 'opencode', status: 'ok', itemsFound: 1 },
-      { id: 'openclaw', status: 'ok', itemsFound: 1 },
-      { id: 'claude', status: 'ok', itemsFound: 1 },
-      { id: 'copilot', status: 'ok', itemsFound: 1 },
-      { id: 'goose', status: 'ok', itemsFound: 1 },
-      { id: 'amp', status: 'ok', itemsFound: 1 },
-      { id: 'qwen', status: 'ok', itemsFound: 1 },
-      { id: 'kimi', status: 'ok', itemsFound: 1 },
-      { id: 'cline', status: 'ok', itemsFound: 1 },
-      { id: 'roocode', status: 'ok', itemsFound: 1 },
-      { id: 'kilocode', status: 'ok', itemsFound: 1 },
-      { id: 'antigravity', status: 'ok', itemsFound: 1 },
+      { id: 'pi', format: 'jsonl', status: 'ok', itemsFound: 1 },
+      { id: 'codex', format: 'jsonl', status: 'ok', itemsFound: 1 },
+      { id: 'gemini', format: 'json', status: 'ok', itemsFound: 1 },
+      { id: 'droid', format: 'json', status: 'ok', itemsFound: 1 },
+      { id: 'opencode', format: 'sqlite', status: 'ok', itemsFound: 1 },
+      { id: 'openclaw', format: 'jsonl', status: 'ok', itemsFound: 1 },
+      { id: 'claude', format: 'jsonl', status: 'ok', itemsFound: 1 },
+      { id: 'copilot', format: 'jsonl', status: 'ok', itemsFound: 1 },
+      { id: 'goose', format: 'sqlite', status: 'ok', itemsFound: 1 },
+      { id: 'amp', format: 'json', status: 'ok', itemsFound: 1 },
+      { id: 'qwen', format: 'jsonl', status: 'ok', itemsFound: 1 },
+      { id: 'kimi', format: 'jsonl', status: 'ok', itemsFound: 1 },
+      { id: 'cline', format: 'json', status: 'ok', itemsFound: 1 },
+      { id: 'roocode', format: 'json', status: 'ok', itemsFound: 1 },
+      { id: 'kilocode', format: 'json', status: 'ok', itemsFound: 1 },
+      { id: 'antigravity', format: 'sqlite', status: 'ok', itemsFound: 1 },
     ]);
   });
 
@@ -347,7 +347,7 @@ describe('run-doctor-report', () => {
       },
     );
 
-    expect(results).toEqual([{ id: 'pi', status: 'ok', itemsFound: 1 }]);
+    expect(results).toEqual([{ id: 'pi', format: 'jsonl', status: 'ok', itemsFound: 1 }]);
   });
 
   it('reports an enabled event store that has not been created yet as healthy', async () => {
@@ -368,9 +368,10 @@ describe('run-doctor-report', () => {
     );
 
     expect(results).toEqual([
-      { id: 'pi', status: 'ok', itemsFound: 1 },
+      { id: 'pi', format: 'jsonl', status: 'ok', itemsFound: 1 },
       {
         id: 'event-store',
+        format: 'sqlite',
         status: 'ok',
         itemsFound: 0,
         detail: 'not yet created',
@@ -407,9 +408,10 @@ describe('run-doctor-report', () => {
     expect(readEventStoreSummarySpy).toHaveBeenCalledWith(eventStorePath);
     expect(readEventStoreStoredFilesSpy).toHaveBeenCalledWith(eventStorePath);
     expect(results).toEqual([
-      { id: 'pi', status: 'ok', itemsFound: 1 },
+      { id: 'pi', format: 'jsonl', status: 'ok', itemsFound: 1 },
       {
         id: 'event-store',
+        format: 'sqlite',
         status: 'ok',
         itemsFound: 42,
         detail: '42 event(s), 0 departed file(s), schema v2, 0 B',
@@ -484,9 +486,10 @@ describe('run-doctor-report', () => {
     );
 
     expect(results).toEqual([
-      { id: 'pi', status: 'ok', itemsFound: 1 },
+      { id: 'pi', format: 'jsonl', status: 'ok', itemsFound: 1 },
       {
         id: 'event-store',
+        format: 'sqlite',
         status: 'error',
         error:
           'Event store schema v999 is not supported by this llm-usage-metrics version (supports v2); upgrade llm-usage-metrics or set LLM_USAGE_EVENT_STORE=0',
@@ -524,9 +527,10 @@ describe('run-doctor-report', () => {
     );
 
     expect(results).toEqual([
-      { id: 'pi', status: 'ok', itemsFound: 1 },
+      { id: 'pi', format: 'jsonl', status: 'ok', itemsFound: 1 },
       {
         id: 'event-store',
+        format: 'sqlite',
         status: 'error',
         error: 'sqlite unavailable',
       },
@@ -549,7 +553,7 @@ describe('run-doctor-report', () => {
       stdout.restore();
     }
 
-    expect(stdout.getOutput()).toContain('gemini  ok');
+    expect(stdout.getOutput()).toContain('✔ gemini  json');
     expect(stdout.getOutput()).toContain('1/1 sources healthy');
   });
 
@@ -570,8 +574,7 @@ describe('run-doctor-report', () => {
       stdout.restore();
     }
 
-    expect(stdout.getOutput()).toContain('claude');
-    expect(stdout.getOutput()).toContain('error');
+    expect(stdout.getOutput()).toContain('✖ claude       jsonl');
     expect(stdout.getOutput()).toContain(missingClaudeDir);
     expect(stdout.getOutput()).toContain('15/16 sources healthy');
   });
@@ -612,7 +615,7 @@ describe('run-doctor-report', () => {
     }
 
     expect(JSON.parse(stdout.getOutput())).toEqual({
-      sources: [{ id: 'gemini', status: 'ok', itemsFound: 1 }],
+      sources: [{ id: 'gemini', format: 'json', status: 'ok', itemsFound: 1 }],
     });
   });
 });

--- a/tests/cli/run-usage-report.test.ts
+++ b/tests/cli/run-usage-report.test.ts
@@ -724,7 +724,7 @@ describe('buildUsageReport', () => {
     const svgContent = await readFile(svgPath, 'utf8');
 
     expect(svgContent).toContain('<svg');
-    expect(svgContent).toContain('TOKENS');
+    expect(svgContent).toContain('Tokens');
     expect(svgContent).toContain('llm-usage monthly --share');
     expect(stderrLines.some((line) => line.includes('Wrote usage share SVG'))).toBe(true);
     expect(logCallCount).toBe(1);

--- a/tests/cli/run-wrapped-report.test.ts
+++ b/tests/cli/run-wrapped-report.test.ts
@@ -26,6 +26,10 @@ vi.mock('../../src/cli/build-wrapped-data.js', async (importOriginal) => {
           totalTokens: index * 10,
           level: index === 0 ? 0 : 1,
         })),
+        dailyIntensity: Array.from({ length: 365 }, (_, index) => {
+          const date = new Date(Date.UTC(2026, 0, 1 + index)).toISOString().slice(0, 10);
+          return { date, totalTokens: index % 5, level: (index % 5) as 0 | 1 | 2 | 3 | 4 };
+        }),
       },
       diagnostics: {
         sessionStats: [],
@@ -80,6 +84,10 @@ function createRecap(overrides: Partial<WrappedRecap> = {}): WrappedRecap {
       totalTokens: level * 100,
       level: level as 0 | 1 | 2 | 3 | 4,
     })),
+    dailyIntensity: Array.from({ length: 365 }, (_, index) => {
+      const date = new Date(Date.UTC(2026, 0, 1 + index)).toISOString().slice(0, 10);
+      return { date, totalTokens: index % 5, level: (index % 5) as 0 | 1 | 2 | 3 | 4 };
+    }),
     ...overrides,
   };
 }

--- a/tests/render/render-trends-share-svg.test.ts
+++ b/tests/render/render-trends-share-svg.test.ts
@@ -55,8 +55,8 @@ describe('renderTrendsShareSvg', () => {
   it('escapes the rendered series label', () => {
     const svg = renderTrendsShareSvg(createData());
 
-    expect(svg).toContain('Series: combined &lt;all&gt;');
-    expect(svg).not.toContain('Series: combined <all>');
+    expect(svg).toContain('· combined &lt;all&gt;');
+    expect(svg).not.toContain('combined <all>');
   });
 
   it('renders a single-day cost trend as one marker', () => {

--- a/tests/render/render-usage-share-svg.test.ts
+++ b/tests/render/render-usage-share-svg.test.ts
@@ -152,64 +152,6 @@ function createEmptyData(): UsageDataResult {
   };
 }
 
-function createLargeTotalData(): UsageDataResult {
-  return {
-    events: [],
-    rows: [
-      {
-        rowType: 'period_source',
-        periodKey: '2026-02',
-        source: 'codex',
-        models: ['gpt-4.1'],
-        modelBreakdown: [],
-        inputTokens: 0,
-        outputTokens: 0,
-        reasoningTokens: 0,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
-        totalTokens: 296_700_000,
-        costUsd: 109.98,
-      },
-      {
-        rowType: 'period_source',
-        periodKey: '2026-02',
-        source: 'pi',
-        models: ['claude-4-sonnet'],
-        modelBreakdown: [],
-        inputTokens: 0,
-        outputTokens: 0,
-        reasoningTokens: 0,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
-        totalTokens: 58_700,
-        costUsd: 0,
-      },
-      {
-        rowType: 'grand_total',
-        periodKey: 'ALL',
-        source: 'combined',
-        models: ['gpt-4.1', 'claude-4-sonnet'],
-        modelBreakdown: [],
-        inputTokens: 0,
-        outputTokens: 0,
-        reasoningTokens: 0,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
-        totalTokens: 296_800_000,
-        costUsd: 109.98,
-      },
-    ],
-    diagnostics: {
-      sessionStats: [],
-      sourceFailures: [],
-      skippedRows: [],
-      pricingOrigin: 'none',
-      activeEnvOverrides: [],
-      timezone: 'UTC',
-    },
-  };
-}
-
 function createManySourcesData(sourceNames: string[]): UsageDataResult {
   const sourceRows = sourceNames.map((source, i) => ({
     rowType: 'period_source' as const,
@@ -257,16 +199,15 @@ function createManySourcesData(sourceNames: string[]): UsageDataResult {
   };
 }
 
-// Pill badges are the only rects with height="30" rx="15" fill-opacity="0.15".
-const pillRectPattern =
-  /<rect x="([0-9.]+)" y="([0-9.]+)" width="([0-9.]+)" height="30" rx="15" fill="([^"]+)" fill-opacity="0\.15"/g;
+const legendPattern =
+  /<circle data-legend="([^"]+)" cx="([0-9.]+)" cy="([0-9.]+)" r="5" fill="([^"]+)"\/>/g;
 
 describe('renderUsageShareSvg', () => {
-  it('renders a stacked area SVG with source legend and period labels', () => {
+  it('renders a stacked area SVG with title, stats, legend, and period labels', () => {
     const svg = renderUsageShareSvg(createMultiSourceData(), 'monthly');
 
-    expect(svg).toContain('<svg');
-    expect(svg).toContain('TOKENS');
+    expect(svg).toContain('Monthly Usage');
+    expect(svg).toContain('Tokens');
     expect(svg).toContain('pi');
     expect(svg).toContain('codex');
     expect(svg).toContain('2026-01');
@@ -294,9 +235,10 @@ describe('renderUsageShareSvg', () => {
     expect(svg).toContain('llm-usage daily --share');
   });
 
-  it('adapts command badge text to granularity', () => {
+  it('adapts the title and command badge to granularity', () => {
+    expect(renderUsageShareSvg(createEmptyData(), 'daily')).toContain('Daily Usage');
     expect(renderUsageShareSvg(createEmptyData(), 'daily')).toContain('llm-usage daily --share');
-    expect(renderUsageShareSvg(createEmptyData(), 'weekly')).toContain('llm-usage weekly --share');
+    expect(renderUsageShareSvg(createEmptyData(), 'weekly')).toContain('Weekly Usage');
     expect(renderUsageShareSvg(createEmptyData(), 'monthly')).toContain(
       'llm-usage monthly --share',
     );
@@ -316,63 +258,50 @@ describe('renderUsageShareSvg', () => {
     expect(svg).not.toContain('clip-path="url(#chart-clip)"');
   });
 
-  it('offsets source pills to avoid overlapping wide stat totals', () => {
-    const svg = renderUsageShareSvg(createLargeTotalData(), 'monthly');
-    const firstPillRectMatch =
-      /<rect x="([0-9.]+)" y="34" width="[0-9.]+" height="30" rx="15" fill="[^"]+" fill-opacity="0.15"/.exec(
-        svg,
-      );
-    expect(firstPillRectMatch).toBeTruthy();
-
-    const firstPillX = Number(firstPillRectMatch?.[1]);
-    expect(firstPillX).toBeGreaterThan(270);
-  });
-
-  it('wraps many source pills across rows without clipping the canvas', () => {
+  it('wraps many legend items across rows without leaving the canvas', () => {
     const names = Array.from({ length: 14 }, (_, i) => `sourcelongname${i}`);
     const svg = renderUsageShareSvg(createManySourcesData(names), 'monthly');
-    const pills = [...svg.matchAll(pillRectPattern)];
+    const items = [...svg.matchAll(legendPattern)];
 
-    expect(pills).toHaveLength(14);
-    for (const pill of pills) {
-      const rightEdge = Number(pill[1]) + Number(pill[3]);
-      expect(rightEdge).toBeLessThanOrEqual(1500 - 40);
+    expect(items).toHaveLength(14);
+    for (const item of items) {
+      expect(Number(item[2])).toBeLessThanOrEqual(1500 - 80);
     }
 
-    const distinctRows = new Set(pills.map((pill) => pill[2]));
+    const distinctRows = new Set(items.map((item) => item[3]));
     expect(distinctRows.size).toBeGreaterThanOrEqual(2);
   });
 
-  it('keeps a single row at the base height for a few sources', () => {
+  it('keeps a single legend row at the base height for a few sources', () => {
     const svg = renderUsageShareSvg(createManySourcesData(['alpha', 'beta', 'gamma']), 'monthly');
-    const pills = [...svg.matchAll(pillRectPattern)];
+    const items = [...svg.matchAll(legendPattern)];
 
-    expect(svg).toContain('height="560"');
-    expect(svg).toContain('viewBox="0 0 1500 560"');
-    expect(new Set(pills.map((pill) => pill[2]))).toEqual(new Set(['34']));
+    expect(svg).toContain('height="620"');
+    expect(svg).toContain('viewBox="0 0 1500 620"');
+    expect(new Set(items.map((item) => item[3]))).toEqual(new Set(['158']));
   });
 
-  it('grows the canvas and shifts the chart and footer down per wrapped row', () => {
+  it('grows the canvas and shifts the chart and footer down per wrapped legend row', () => {
     const names = Array.from({ length: 14 }, (_, i) => `sourcelongname${i}`);
     const svg = renderUsageShareSvg(createManySourcesData(names), 'monthly');
-    const rowCount = new Set([...svg.matchAll(pillRectPattern)].map((pill) => pill[2])).size;
-    const extraHeight = (rowCount - 1) * 40;
-    const height = 560 + extraHeight;
+    const rowCount = new Set([...svg.matchAll(legendPattern)].map((item) => item[3])).size;
+    const extraHeight = (rowCount - 1) * 30;
+    const height = 620 + extraHeight;
 
     expect(rowCount).toBeGreaterThanOrEqual(2);
     expect(svg).toContain(`height="${height}"`);
     expect(svg).toContain(`viewBox="0 0 1500 ${height}"`);
     // Footer line sits at H - footerHeight + 1; the top grid line at chartTop.
     expect(svg).toContain(`<line x1="0" y1="${height - 36 + 1}"`);
-    expect(svg).toContain(`y1="${(140 + extraHeight).toFixed(2)}"`);
+    expect(svg).toContain(`y1="${(208 + extraHeight).toFixed(2)}"`);
   });
 
-  it('gives each of 16 fallback sources a distinct pill color', () => {
+  it('gives each of 16 fallback sources a distinct legend color', () => {
     const names = Array.from({ length: 16 }, (_, i) => `custom${String.fromCharCode(97 + i)}`);
     const svg = renderUsageShareSvg(createManySourcesData(names), 'monthly');
-    const pills = [...svg.matchAll(pillRectPattern)];
+    const items = [...svg.matchAll(legendPattern)];
 
-    expect(pills).toHaveLength(16);
-    expect(new Set(pills.map((pill) => pill[4])).size).toBe(16);
+    expect(items).toHaveLength(16);
+    expect(new Set(items.map((item) => item[4])).size).toBe(16);
   });
 });

--- a/tests/render/render-wrapped-share-svg.test.ts
+++ b/tests/render/render-wrapped-share-svg.test.ts
@@ -36,11 +36,15 @@ function createRecap(): WrappedRecap {
       totalTokens: index * 100,
       level: Math.min(4, index) as 0 | 1 | 2 | 3 | 4,
     })),
+    dailyIntensity: Array.from({ length: 365 }, (_, index) => {
+      const date = new Date(Date.UTC(2026, 0, 1 + index)).toISOString().slice(0, 10);
+      return { date, totalTokens: index % 5, level: (index % 5) as 0 | 1 | 2 | 3 | 4 };
+    }),
   };
 }
 
 describe('renderWrappedShareSvg', () => {
-  it('renders stat tiles, top lists, monthly intensity, command badge, and footer', () => {
+  it('renders stat tiles, top lists, daily heatmap, command badge, and footer', () => {
     const svg = renderWrappedShareSvg(createRecap());
 
     expect(svg).toContain('<svg');
@@ -52,10 +56,10 @@ describe('renderWrappedShareSvg', () => {
     expect(svg).toContain('~$123.45');
     expect(svg).toContain('Top Models');
     expect(svg).toContain('Top Sources');
-    expect(svg).toContain('Monthly intensity');
+    expect(svg).toContain('Daily activity');
     expect(svg).toContain('llm-usage wrapped --year 2026 --share');
     expect(svg).toContain('llm-usage-metrics');
-    expect(svg.match(/data-month="/g)).toHaveLength(12);
+    expect(svg.match(/data-date="/g)).toHaveLength(365);
   });
 
   it('escapes model and source names', () => {

--- a/tests/wrapped/aggregate-wrapped.test.ts
+++ b/tests/wrapped/aggregate-wrapped.test.ts
@@ -204,6 +204,55 @@ describe('aggregateWrapped', () => {
     expect(recap.longestStreak).toBe(0);
   });
 
+  it('builds one all-zero daily intensity bucket per day for an empty year', () => {
+    const recap = aggregateWrapped([], { year: 2026, timezone: 'UTC' });
+
+    expect(recap.dailyIntensity).toHaveLength(365);
+    expect(recap.dailyIntensity[0]).toEqual({ date: '2026-01-01', totalTokens: 0, level: 0 });
+    expect(recap.dailyIntensity.at(-1)).toEqual({ date: '2026-12-31', totalTokens: 0, level: 0 });
+  });
+
+  it('covers leap years with 366 daily intensity buckets', () => {
+    const recap = aggregateWrapped([], { year: 2028, timezone: 'UTC' });
+
+    expect(recap.dailyIntensity).toHaveLength(366);
+    expect(recap.dailyIntensity[59]).toEqual({ date: '2028-02-29', totalTokens: 0, level: 0 });
+  });
+
+  it('bands daily intensity levels by quartile of the active days', () => {
+    const recap = aggregateWrapped(
+      [
+        baseEvent({ timestamp: '2026-01-01T10:00:00.000Z', totalTokens: 25 }),
+        baseEvent({ timestamp: '2026-01-02T10:00:00.000Z', totalTokens: 50 }),
+        baseEvent({ timestamp: '2026-01-03T10:00:00.000Z', totalTokens: 100 }),
+      ],
+      { year: 2026, timezone: 'UTC' },
+    );
+
+    expect(recap.dailyIntensity.slice(0, 4).map((day) => day.level)).toEqual([1, 2, 4, 0]);
+    expect(recap.dailyIntensity[2]).toEqual({ date: '2026-01-03', totalTokens: 100, level: 4 });
+  });
+
+  it('keeps quartile banding stable when one outlier day dwarfs the rest', () => {
+    const typicalDays = Array.from({ length: 8 }, (_, index) =>
+      baseEvent({
+        timestamp: `2026-01-0${index + 1}T10:00:00.000Z`,
+        totalTokens: 100 + index,
+      }),
+    );
+    const recap = aggregateWrapped(
+      [
+        ...typicalDays,
+        baseEvent({ timestamp: '2026-01-09T10:00:00.000Z', totalTokens: 1_000_000 }),
+      ],
+      { year: 2026, timezone: 'UTC' },
+    );
+    const levels = recap.dailyIntensity.slice(0, 9).map((day) => day.level);
+
+    expect(new Set(levels).size).toBeGreaterThan(2);
+    expect(levels.at(-1)).toBe(4);
+  });
+
   it('scales monthly intensity levels against the busiest month', () => {
     const recap = aggregateWrapped(
       [


### PR DESCRIPTION
Refreshes the landing page branding and rewrites the README and site docs around the current product behavior. Adds the compare guide, clarifies source and pricing semantics, improves navigation and GitHub Pages base-path links, and updates the visual system. Validation completed: lint, typecheck, tests (1260 passing), format check, site check, site build, and desktop/mobile light/dark browser QA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reorganized the README into quick start, report mapping, supported sources, configuration, pricing, local event ledger, output, performance, and development.
  - Updated site docs and navigation with the new URL namespace and refreshed several report explanations (compare/efficiency/getting started/output/sources/trends/wrapped).
- **New Features**
  - Enhanced `llm-usage wrapped` share SVGs with a day-by-day activity heatmap; recap JSON now includes daily intensity.
- **Bug Fixes**
  - Improved `llm-usage doctor` output with glyph health indicators and per-source storage format details.
- **Tests**
  - Updated doctor/wrapped/share SVG expectations to match the new outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->