### PR TITLE
Landing: add Export card (events/schema) to the report grid

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -62,7 +62,7 @@ const reportGroups = [
     doc: 'doctor/',
     question: 'Is my local data healthy?',
     answer: 'Probe every discovery path, inspect the event ledger, and preview retained-history cleanup before deleting anything.',
-    commands: ['doctor', 'prune'],
+    commands: ['doctor', 'prune', 'config show'],
   },
   {
     number: '06',
@@ -71,6 +71,14 @@ const reportGroups = [
     question: 'What did the year look like?',
     answer: 'Summarize active days, streaks, models, sources, tokens, and estimated cost in one terminal recap or SVG.',
     commands: ['wrapped'],
+  },
+  {
+    number: '07',
+    label: 'Export',
+    doc: 'events/',
+    question: 'Can I take the data with me?',
+    answer: 'Stream every normalized event as JSONL or CSV for jq, DuckDB, or warehouse workflows — with published JSON Schemas to validate any report output against.',
+    commands: ['events --format csv', 'schema usage'],
   },
 ];
 


### PR DESCRIPTION
The report grid predated the 0.8.0 `events`, `schema`, and `config show` commands. Adds a seventh **Export** card (`events --format csv`, `schema usage`) — which also fills the previously empty grid cell next to Wrapped — and a `config show` chip on the Health card. Site format/check/build green; screenshot-verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Export report group with guidance for exporting event data.
  - Added example commands for CSV event exports and schema usage.
  - Expanded Health report options to include the `config show` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->