### PR TITLE
docs: polish sharing and release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,28 @@ Report data goes to `stdout`. Discovery, pricing, config, and skipped-row diagno
 
 Terminal, JSON, and Markdown availability varies by report. Usage, trends, wrapped, efficiency, and optimize can write supported share SVGs. The [output guide](https://ayagmar.github.io/llm-usage-metrics/output-formats/) contains the format matrix and file names.
 
+### Shareable snapshots
+
+Share cards are deterministic, offline SVG files. They contain aggregated metrics only—not prompts, message text, file contents, or credentials—so you can review the image before posting it anywhere.
+
+```bash
+# Write a monthly card without changing the report on stdout
+llm-usage monthly --share > monthly.txt
+
+# Open the generated SVG, then attach it to a post or issue
+open usage-monthly-share.svg        # macOS
+xdg-open usage-monthly-share.svg    # Linux
+```
+
+Examples from the repository:
+
+<p>
+  <a href="./usage-monthly-share.svg"><img src="./usage-monthly-share.svg" width="49%" alt="Example monthly usage share card"></a>
+  <a href="./trends-share.svg"><img src="./trends-share.svg" width="49%" alt="Example usage trends share card"></a>
+</p>
+
+The complete format matrix, filenames, and limitations are in the [output guide](https://ayagmar.github.io/llm-usage-metrics/output-formats/). For a launch-ready message, see the [LinkedIn post draft](./docs/marketing/linkedin-post.md).
+
 ## Performance
 
 The repository publishes direct-process and launcher-inclusive runtimes on stable snapshots of real local corpora. The current direct-process comparison shows `ccusage` ahead in every measured daily JSON cell; a separate monthly terminal check shows why timing `npx ccusage@...` can appear much slower than an installed `llm-usage` command. The benchmark records the machine, exact commands, application state, dataset size, and eight-run summary statistics.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ This folder contains internal technical documentation for `llm-usage-metrics` co
 - [Architecture](./architecture.md) - Runtime flow and module boundaries
 - [Development Guide](./development.md) - Setup, build, test workflows
 - [Security Guide](./security.md) - Security controls, dependency hygiene, and contributor steps
+- [Production Release Checklist](./release-checklist.md) - Verification and approval gates before publishing
+- [LinkedIn Post Draft](./marketing/linkedin-post.md) - A privacy-conscious launch message and posting checklist
 - [Contributing Guide](../CONTRIBUTING.md) - Contribution guidelines
 
 ## Documentation Structure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,7 @@ That keeps sorting and separator behavior deterministic without coupling the gen
 - `src/pricing`
   LiteLLM pricing loader, cache, model matching, cost engine
 - `src/persistence`
-  SQLite event-store ledger, schema migrations, history suppression
+  SQLite event-store ledger. `event-store.ts` is the public facade; schema/migrations, database primitives, row codecs/hashing, administration, and history suppression live in focused modules behind it.
 - `src/aggregate`
   Period/source usage aggregation
 - `src/efficiency`

--- a/docs/marketing/linkedin-post.md
+++ b/docs/marketing/linkedin-post.md
@@ -1,0 +1,36 @@
+# LinkedIn post draft
+
+## Suggested post
+
+I built `llm-usage-metrics` to answer a simple question: what am I actually using across all of my AI coding tools?
+
+It reads local session data from 16 tools, normalizes the events, estimates cost with a bundled pricing snapshot, and turns the result into practical reports:
+
+- daily, weekly, and monthly usage
+- period comparisons and trends
+- session and repository breakdowns
+- Git-attributed efficiency
+- candidate-model cost comparisons
+- a yearly “wrapped” recap
+- JSON, Markdown, and shareable offline SVG cards
+
+The important design choice is privacy: parsing happens locally, and the share cards contain aggregated metrics—not prompts, message text, or file contents. The CLI also works offline with its bundled pricing snapshot.
+
+If you want to understand your own AI-assisted development patterns, try:
+
+```bash
+npx --yes llm-usage-metrics@latest daily
+llm-usage monthly --share
+```
+
+Project: https://github.com/ayagmar/llm-usage-metrics
+Docs: https://ayagmar.github.io/llm-usage-metrics/
+
+#AI #DeveloperTools #OpenSource #TypeScript #CLI #Privacy
+
+## Posting checklist
+
+- Attach a reviewed share SVG; do not post raw JSON or session exports.
+- Replace the example date range with the period shown in the image.
+- Mention that metrics are local estimates when discussing cost.
+- Link to the repository and documentation rather than embedding credentials or local paths.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,40 @@
+# Production Release Checklist
+
+Use this checklist for a release candidate. It intentionally stops before publishing: release approval and the version/tag decision remain human decisions.
+
+## Before the release PR
+
+- [ ] Confirm the working tree is clean and the release branch is based on `master`.
+- [ ] Review user-visible changes in `CHANGELOG.md`, `README.md`, and `site/src/content/docs/`.
+- [ ] Regenerate generated docs with `pnpm run site:docs:generate` and confirm there is no diff afterward.
+- [ ] Confirm `pnpm-lock.yaml` matches every workspace manifest with `pnpm install --frozen-lockfile`.
+- [ ] Review action references with `actionlint` and `uvx zizmor --pedantic .github/workflows`.
+- [ ] Run `pnpm audit --audit-level=moderate` and resolve reachable high/critical findings.
+
+## Verification gate
+
+Run the same checks as CI from a clean install:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run verify:ci
+```
+
+The gate covers lint, typecheck, tests and coverage thresholds, formatting, Mermaid validation, production build, distribution smoke test, package contents, generated docs, Astro checks, and site build.
+
+## Release safety
+
+- [ ] Review the package contents with `pnpm run pack:check`; do not ship local fixtures, coverage, or source-only files.
+- [ ] Check the generated tarball includes the README and license and exposes only the `llm-usage` binary.
+- [ ] Confirm the runtime requirement (Node.js 24+) and package manager pin are documented.
+- [ ] Confirm no command in the release workflow publishes unless the release job is intentionally dispatched.
+- [ ] Confirm pricing behavior is acceptable offline and that no session content is sent to the pricing service.
+- [ ] Review share artifacts for sensitive data before attaching them to public posts.
+- [ ] Get explicit approval for the version, tag, npm publication, and GitHub release.
+
+## After approval
+
+- [ ] Run the release command from the approved commit.
+- [ ] Verify the npm tarball, GitHub release, and documentation deployment.
+- [ ] Install the published version in a clean Node.js 24 environment and run `llm-usage doctor`.
+- [ ] Record the version, commit SHA, verification result, and rollback notes in the release PR.

--- a/site/src/content/docs/architecture/event-store.mdx
+++ b/site/src/content/docs/architecture/event-store.mdx
@@ -5,6 +5,16 @@ description: 'Design of the SQLite usage-event ledger: ingest, fingerprints, his
 
 The event store (`src/persistence/event-store.ts`) is a local SQLite **ledger**, not a disposable cache. It solves three problems at once: warm runs skip reparsing files that have not changed, usage from files that later disappear stays reportable through `--history`, and a file that merely moved is recognized by content so it never double counts. Because the ledger retains rows for departed files, deleting `events.db` deletes that retained history — you get a fresh ledger, not just a slower next run.
 
+The public facade stays intentionally small while the implementation is split by responsibility:
+
+- `event-store-schema.ts` owns schema creation, version checks, and migrations.
+- `event-store-database.ts` owns the SQLite handle, transactions, and primitive value conversions.
+- `event-store-codec.ts` owns row normalization and content hashing.
+- `event-store-administration.ts` owns open, ingest, summaries, file listing, and prune operations.
+- `event-store-history.ts` owns departed-file replay and move suppression.
+
+This is an internal boundary: callers continue to use `event-store.ts`, so the persistence API and schema remain stable.
+
 ## Location and lifecycle
 
 - **Default path**: `getDefaultEventStorePath()` resolves to `llm-usage-metrics/events.db` under the platform cache root — `~/.cache/llm-usage-metrics/events.db` on Linux when `XDG_CACHE_HOME` is unset.

--- a/site/src/content/docs/output-formats.mdx
+++ b/site/src/content/docs/output-formats.mdx
@@ -71,6 +71,8 @@ Usage and session output keep the same ordering and row limits as the terminal r
 
 Share output is an offline SVG written to the current directory. The command still prints the normal report to `stdout`.
 
+The image contains aggregated metrics only: prompts, message text, file contents, and credentials are never rendered into a share card. Open the generated file and review it before posting it publicly.
+
 | Report | Command | File |
 | --- | --- | --- |
 | Usage | `llm-usage monthly --share` | `usage-monthly-share.svg` |
@@ -83,6 +85,8 @@ Share output is an offline SVG written to the current directory. The command sti
 Usage share works for daily, weekly, and monthly reports. Efficiency and optimize share work for monthly reports only. Trends share requires the combined view, so it cannot be paired with `--by-source`. Efficiency share cannot be paired with `--by-source` either.
 
 Session, doctor, prune, and events do not support `--share`.
+
+The repository README includes [example share cards](https://github.com/ayagmar/llm-usage-metrics#shareable-snapshots) so you can see the intended output before running a report.
 
 ## Per-model columns
 


### PR DESCRIPTION
## Summary
- add README share-card gallery and privacy guidance
- document the split event-store internals
- add production release checklist and LinkedIn post draft

## Validation
- `pnpm run verify:ci`
- 155 test files / 1,377 tests passed
- coverage: 96.09% statements, 90.24% branches
- site check and build passed

No release or publication was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating and reviewing shareable SVG snapshots containing aggregated metrics only.
  * Added example commands and preview images for monthly usage and trend reports.
  * Added a production release checklist covering verification, packaging, security, and deployment steps.
  * Added a LinkedIn launch post draft and contributor documentation links.
  * Clarified the event store architecture and stable persistence interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->